### PR TITLE
Fix latent sizing bugs and expand to 30 model families (v1.5.0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Unit tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.12"]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run tests
+        # torch is stubbed by the suite, so no ComfyUI install is required.
+        run: python -m unittest discover -s tests -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+build/
+dist/
+.venv/
+venv/
+.pytest_cache/
+.DS_Store

--- a/Bobs_Latent_Optimizer.py
+++ b/Bobs_Latent_Optimizer.py
@@ -39,8 +39,17 @@ MAX_TILE_DIM = 2048
 #               dimensions actually describe the tensor we return
 #   temporal  - temporal downscale (temporal_downscale_ratio); video models only
 #   dims      - 2 for image models ([B,C,H,W]), 3 for video ([B,C,T,H,W])
+#   starts_from_empty - False for models that are never driven from an empty
+#               latent (refiners, restorers). Defaults to True.
 #
 # Video latents use ComfyUI's frame formula: ((length - 1) // temporal) + 1.
+#
+# Two entries deliberately deviate from the format they map to. QWEN and
+# COSMOS_PREDICT2 both use latent_formats.Wan21, which declares
+# latent_dimensions=3 and temporal_downscale_ratio=4, because they share Wan's
+# VAE. Both are still-image models though - ComfyUI's own Qwen workflows use
+# EmptySD3LatentImage, which is 4-D - so we follow the workflow rather than the
+# shared format and treat them as 2-D.
 MODEL_SPECS = {
     # --- 4-channel SD-family VAE ---
     "SD15": {"channels": 4, "vae_scale": 8, "align": 64, "temporal": 1, "dims": 2},
@@ -61,15 +70,33 @@ MODEL_SPECS = {
     # --- high-channel / high-compression image models ---
     "FLUX2": {"channels": 128, "vae_scale": 16, "align": 64, "temporal": 1, "dims": 2},
     "HUNYUAN_IMAGE": {"channels": 64, "vae_scale": 32, "align": 64, "temporal": 1, "dims": 2},
-    # Chroma Radiance works directly in pixel space - no VAE downscale at all.
+    # --- pixel-space image models: no VAE at all, so the "latent" IS the image.
+    # Alignment of 16 matches the step on ComfyUI's own pixel-space latent node.
     "CHROMA_RADIANCE": {"channels": 3, "vae_scale": 1, "align": 16, "temporal": 1, "dims": 2},
+    "HIDREAM_O1": {"channels": 3, "vae_scale": 1, "align": 16, "temporal": 1, "dims": 2},
+    "ZIMAGE_PIXEL": {"channels": 3, "vae_scale": 1, "align": 16, "temporal": 1, "dims": 2},
+    "PIXELDIT": {"channels": 3, "vae_scale": 1, "align": 16, "temporal": 1, "dims": 2},
     # --- video models (5-D latents; use the `length` input) ---
     "WAN": {"channels": 16, "vae_scale": 8, "align": 16, "temporal": 4, "dims": 3},
     "WAN22": {"channels": 48, "vae_scale": 16, "align": 32, "temporal": 4, "dims": 3},
     "HUNYUAN_VIDEO": {"channels": 16, "vae_scale": 8, "align": 16, "temporal": 4, "dims": 3},
+    "HUNYUAN_VIDEO_15": {"channels": 32, "vae_scale": 16, "align": 32, "temporal": 4, "dims": 3},
     "COSMOS": {"channels": 16, "vae_scale": 8, "align": 16, "temporal": 8, "dims": 3},
+    "COGVIDEOX": {"channels": 16, "vae_scale": 8, "align": 16, "temporal": 4, "dims": 3},
     "MOCHI": {"channels": 12, "vae_scale": 8, "align": 16, "temporal": 6, "dims": 3},
     "LTXV": {"channels": 128, "vae_scale": 32, "align": 32, "temporal": 8, "dims": 3},
+    # --- shape-only: these models are never driven from an empty latent.
+    # SeedVR2 restores existing video (its preprocess node takes an IMAGE), and
+    # the HunyuanImage 2.1 refiner consumes the base model's latent. Included so
+    # the shapes are available, but selecting them logs a warning.
+    "SEEDVR2": {
+        "channels": 16, "vae_scale": 8, "align": 16, "temporal": 1, "dims": 3,
+        "starts_from_empty": False,
+    },
+    "HUNYUAN_IMAGE_REFINER": {
+        "channels": 64, "vae_scale": 8, "align": 16, "temporal": 1, "dims": 3,
+        "starts_from_empty": False,
+    },
 }
 
 MODEL_TYPES = list(MODEL_SPECS.keys())
@@ -318,6 +345,14 @@ class _BobsLatentBase:
         if spec is None:
             raise ValueError(
                 f"Unknown model_type {model_type!r}. Expected one of {', '.join(MODEL_TYPES)}."
+            )
+
+        if not spec.get("starts_from_empty", True):
+            logger.warning(
+                "Bobs Latent Optimizer: %s is not normally driven from an empty latent - it "
+                "consumes an existing image or latent. This gives you a correctly shaped zero "
+                "tensor, but it is probably not the input that model wants.",
+                model_type,
             )
 
         aspect_ratio_multiplier = parse_aspect_ratio(aspect_ratio)

--- a/Bobs_Latent_Optimizer.py
+++ b/Bobs_Latent_Optimizer.py
@@ -1,7 +1,13 @@
 """Bobs Latent Optimizer - empty latent generation with model-aware sizing.
 
-Generates empty latents whose pixel dimensions are legal for the selected model
-family, and derives sensible tile dimensions for a downstream tiled upscaler.
+Generates empty latents whose pixel dimensions, channel count and rank are legal
+for the selected model family, and derives sensible tile dimensions for a
+downstream tiled upscaler.
+
+Every entry in MODEL_SPECS is taken from ComfyUI's own `comfy/latent_formats.py`
+(`latent_channels`, `latent_dimensions`, `spacial_downscale_ratio`,
+`temporal_downscale_ratio`) and cross-checked against the matching
+`Empty*Latent*` node in `nodes.py` / `comfy_extras/`.
 """
 
 import logging
@@ -22,27 +28,53 @@ except ImportError:
 
 MP_BASE_AREA = 1024 * 1024
 
-VAE_SCALE_FACTOR = 8
-
 MAX_TILE_DIM = 2048
 
-# Per-model latent channel count and pixel alignment.
+# Model table.
 #
-# `channels` is the channel count of the model's VAE: SDXL is the only 4-channel
-# family here. FLUX, SD3/3.5, Qwen-Image and Wan all use 16-channel VAEs.
+#   channels  - latent channel count (latent_formats.latent_channels)
+#   vae_scale - spatial downscale from pixels to latent (spacial_downscale_ratio)
+#   align     - pixel alignment; MUST be a multiple of vae_scale so that
+#               pixel_size // vae_scale is exact and the reported pixel
+#               dimensions actually describe the tensor we return
+#   temporal  - temporal downscale (temporal_downscale_ratio); video models only
+#   dims      - 2 for image models ([B,C,H,W]), 3 for video ([B,C,T,H,W])
 #
-# `align` must stay a multiple of VAE_SCALE_FACTOR so that
-# pixel_size // VAE_SCALE_FACTOR is exact and the reported pixel dimensions
-# actually describe the tensor we return.
+# Video latents use ComfyUI's frame formula: ((length - 1) // temporal) + 1.
 MODEL_SPECS = {
-    "FLUX": {"channels": 16, "align": 64},
-    "SDXL": {"channels": 4, "align": 64},
-    "SD3": {"channels": 16, "align": 64},
-    "QWEN": {"channels": 16, "align": 16},
-    "WAN": {"channels": 16, "align": 16},
+    # --- 4-channel SD-family VAE ---
+    "SD15": {"channels": 4, "vae_scale": 8, "align": 64, "temporal": 1, "dims": 2},
+    "SD21": {"channels": 4, "vae_scale": 8, "align": 64, "temporal": 1, "dims": 2},
+    "SDXL": {"channels": 4, "vae_scale": 8, "align": 64, "temporal": 1, "dims": 2},
+    "PIXART": {"channels": 4, "vae_scale": 8, "align": 64, "temporal": 1, "dims": 2},
+    "AURAFLOW": {"channels": 4, "vae_scale": 8, "align": 64, "temporal": 1, "dims": 2},
+    "HUNYUAN_DIT": {"channels": 4, "vae_scale": 8, "align": 64, "temporal": 1, "dims": 2},
+    # --- 16-channel image models ---
+    "SD3": {"channels": 16, "vae_scale": 8, "align": 64, "temporal": 1, "dims": 2},
+    "FLUX": {"channels": 16, "vae_scale": 8, "align": 64, "temporal": 1, "dims": 2},
+    "CHROMA": {"channels": 16, "vae_scale": 8, "align": 64, "temporal": 1, "dims": 2},
+    "HIDREAM": {"channels": 16, "vae_scale": 8, "align": 64, "temporal": 1, "dims": 2},
+    "LUMINA2": {"channels": 16, "vae_scale": 8, "align": 64, "temporal": 1, "dims": 2},
+    "OMNIGEN2": {"channels": 16, "vae_scale": 8, "align": 64, "temporal": 1, "dims": 2},
+    "QWEN": {"channels": 16, "vae_scale": 8, "align": 16, "temporal": 1, "dims": 2},
+    "COSMOS_PREDICT2": {"channels": 16, "vae_scale": 8, "align": 16, "temporal": 1, "dims": 2},
+    # --- high-channel / high-compression image models ---
+    "FLUX2": {"channels": 128, "vae_scale": 16, "align": 64, "temporal": 1, "dims": 2},
+    "HUNYUAN_IMAGE": {"channels": 64, "vae_scale": 32, "align": 64, "temporal": 1, "dims": 2},
+    # Chroma Radiance works directly in pixel space - no VAE downscale at all.
+    "CHROMA_RADIANCE": {"channels": 3, "vae_scale": 1, "align": 16, "temporal": 1, "dims": 2},
+    # --- video models (5-D latents; use the `length` input) ---
+    "WAN": {"channels": 16, "vae_scale": 8, "align": 16, "temporal": 4, "dims": 3},
+    "WAN22": {"channels": 48, "vae_scale": 16, "align": 32, "temporal": 4, "dims": 3},
+    "HUNYUAN_VIDEO": {"channels": 16, "vae_scale": 8, "align": 16, "temporal": 4, "dims": 3},
+    "COSMOS": {"channels": 16, "vae_scale": 8, "align": 16, "temporal": 8, "dims": 3},
+    "MOCHI": {"channels": 12, "vae_scale": 8, "align": 16, "temporal": 6, "dims": 3},
+    "LTXV": {"channels": 128, "vae_scale": 32, "align": 32, "temporal": 8, "dims": 3},
 }
 
 MODEL_TYPES = list(MODEL_SPECS.keys())
+
+VIDEO_MODEL_TYPES = [name for name, spec in MODEL_SPECS.items() if spec["dims"] == 3]
 
 # Discrete area presets. These are approximate megapixel labels mapped to common
 # standard resolution areas rather than exact multiples of 1MP.
@@ -60,6 +92,8 @@ MP_SIZE_TO_AREA = {
 }
 
 MP_SIZES = list(MP_SIZE_TO_AREA.keys())
+
+TILE_ALIGN = 8
 
 _ASPECT_SEPARATORS = (":", "/", "x", "X", ",")
 
@@ -126,14 +160,26 @@ def compute_base_dimensions(target_area, aspect_ratio_multiplier, align):
     """
     if target_area <= 0:
         raise ValueError(f"Target area must be positive, got {target_area}.")
+    if align <= 0:
+        raise ValueError(f"Alignment must be positive, got {align}.")
 
     width = math.sqrt(target_area * aspect_ratio_multiplier)
     height = width / aspect_ratio_multiplier
 
-    minimum = max(align, VAE_SCALE_FACTOR)
-    width = max(minimum, round_to_nearest_multiple(width, align))
-    height = max(minimum, round_to_nearest_multiple(height, align))
+    width = max(align, round_to_nearest_multiple(width, align))
+    height = max(align, round_to_nearest_multiple(height, align))
     return width, height
+
+
+def compute_latent_frames(length, temporal):
+    """Latent temporal size for `length` pixel-space frames.
+
+    Matches ComfyUI's video latent nodes: ((length - 1) // temporal) + 1.
+    """
+    length = max(1, int(length))
+    if temporal <= 1:
+        return length
+    return ((length - 1) // temporal) + 1
 
 
 def compute_tile_dimensions(width, height, upscale_by, max_tile_dim=MAX_TILE_DIM):
@@ -141,13 +187,13 @@ def compute_tile_dimensions(width, height, upscale_by, max_tile_dim=MAX_TILE_DIM
 
     Aims for a 2x2 grid, adding tiles along an axis only when a 2x2 tile would
     exceed `max_tile_dim`. Tile dimensions are aligned up to a multiple of
-    VAE_SCALE_FACTOR because tiled VAE/upscaler nodes expect that.
+    TILE_ALIGN because tiled VAE/upscaler nodes expect that.
 
     Returns (tile_width, tile_height, tiles_x, tiles_y).
     """
     upscaled_width = max(1, int(width * upscale_by))
     upscaled_height = max(1, int(height * upscale_by))
-    max_tile_dim = max(VAE_SCALE_FACTOR, int(max_tile_dim))
+    max_tile_dim = max(TILE_ALIGN, int(max_tile_dim))
 
     def axis_tiles(total):
         tiles = 2
@@ -160,9 +206,9 @@ def compute_tile_dimensions(width, height, upscale_by, max_tile_dim=MAX_TILE_DIM
 
     def tile_size(total, tiles):
         size = -(-total // tiles)
-        # Round the tile up to the VAE stride, but never past the whole image.
-        size = -(-size // VAE_SCALE_FACTOR) * VAE_SCALE_FACTOR
-        return max(VAE_SCALE_FACTOR, min(size, total))
+        # Round the tile up to the upscaler stride, but never past the whole image.
+        size = -(-size // TILE_ALIGN) * TILE_ALIGN
+        return max(TILE_ALIGN, min(size, total))
 
     return (
         tile_size(upscaled_width, tiles_x),
@@ -215,8 +261,9 @@ class _BobsLatentBase:
                 {
                     "default": "FLUX",
                     "tooltip": (
-                        "Model family. Sets latent channels (SDXL=4, FLUX/SD3/QWEN/WAN=16) and "
-                        "pixel alignment (64 for FLUX/SDXL/SD3, 16 for QWEN/WAN)."
+                        "Model family. Sets latent channels, VAE downscale and pixel alignment. "
+                        "Video families (" + ", ".join(VIDEO_MODEL_TYPES) + ") produce a 5-D "
+                        "latent and use the `length` input. See the README for the full table."
                     ),
                 },
             ),
@@ -242,9 +289,31 @@ class _BobsLatentBase:
                     ),
                 },
             ),
+            "length": (
+                "INT",
+                {
+                    "default": 1,
+                    "min": 1,
+                    "max": 4096,
+                    "step": 1,
+                    "tooltip": (
+                        "Number of video frames. Only used by video model families; ignored "
+                        "(with a warning) for image models."
+                    ),
+                },
+            ),
         }
 
-    def _build(self, aspect_ratio, target_area, upscale_by, model_type, batch_size, max_tile_size):
+    def _build(
+        self,
+        aspect_ratio,
+        target_area,
+        upscale_by,
+        model_type,
+        batch_size,
+        max_tile_size,
+        length,
+    ):
         spec = MODEL_SPECS.get(model_type)
         if spec is None:
             raise ValueError(
@@ -254,19 +323,31 @@ class _BobsLatentBase:
         aspect_ratio_multiplier = parse_aspect_ratio(aspect_ratio)
         width, height = compute_base_dimensions(target_area, aspect_ratio_multiplier, spec["align"])
 
-        latent_width = width // VAE_SCALE_FACTOR
-        latent_height = height // VAE_SCALE_FACTOR
+        vae_scale = spec["vae_scale"]
+        latent_width = width // vae_scale
+        latent_height = height // vae_scale
         channels = spec["channels"]
 
+        if spec["dims"] == 3:
+            frames = compute_latent_frames(length, spec["temporal"])
+            shape = [batch_size, channels, frames, latent_height, latent_width]
+        else:
+            frames = None
+            if length > 1:
+                logger.warning(
+                    "Bobs Latent Optimizer: length=%d ignored - %s is an image model and "
+                    "produces a 4-D latent. Pick a video model (%s) to use length.",
+                    length,
+                    model_type,
+                    ", ".join(VIDEO_MODEL_TYPES),
+                )
+            shape = [batch_size, channels, latent_height, latent_width]
+
         try:
-            samples = torch.zeros(
-                [batch_size, channels, latent_height, latent_width],
-                device=_latent_device(),
-            )
+            samples = torch.zeros(shape, device=_latent_device())
         except Exception as error:
             raise RuntimeError(
-                f"Could not allocate latent of shape "
-                f"[{batch_size}, {channels}, {latent_height}, {latent_width}] for {model_type}: {error}"
+                f"Could not allocate latent of shape {shape} for {model_type}: {error}"
             )
 
         tile_width, tile_height, tiles_x, tiles_y = compute_tile_dimensions(
@@ -274,15 +355,15 @@ class _BobsLatentBase:
         )
 
         logger.info(
-            "Bobs Latent Optimizer: %s %dx%d px (latent %dx%d, %d channels, batch %d) -> "
+            "Bobs Latent Optimizer: %s %dx%d px%s -> latent %s (/%d, %d channels) | "
             "upscaled %dx%d px in a %dx%d grid of %dx%d tiles",
             model_type,
             width,
             height,
-            latent_width,
-            latent_height,
+            "" if frames is None else f" x {int(length)} frames",
+            tuple(shape),
+            vae_scale,
             channels,
-            batch_size,
             int(width * upscale_by),
             int(height * upscale_by),
             tiles_x,
@@ -298,14 +379,16 @@ class BobsLatentNode(_BobsLatentBase):
     """Generate an empty latent from an aspect ratio and a preset megapixel area.
 
     Pixel dimensions are rounded to the nearest alignment step for the selected
-    model family, and the latent is allocated with that family's channel count.
-    Also returns tile dimensions for a downstream tiled upscaler, targeting a
-    2x2 grid unless that would push a tile past `max_tile_size`.
+    model family, and the latent is allocated with that family's channel count,
+    VAE downscale and rank. Also returns tile dimensions for a downstream tiled
+    upscaler, targeting a 2x2 grid unless that would push a tile past
+    `max_tile_size`.
     """
 
     DESCRIPTION = (
-        "Empty latent sized for FLUX / SDXL / SD3 / Qwen / Wan from an aspect ratio and a "
-        "preset megapixel area, plus suggested tile dimensions for tiled upscaling."
+        "Empty latent sized for a wide range of image and video model families from an "
+        "aspect ratio and a preset megapixel area, plus suggested tile dimensions for "
+        "tiled upscaling."
     )
 
     @classmethod
@@ -332,13 +415,24 @@ class BobsLatentNode(_BobsLatentBase):
         required.update(cls._shared_inputs())
         return {"required": required, "optional": cls._optional_inputs()}
 
-    def generate(self, aspect_ratio, mp_size, upscale_by, model_type, batch_size, max_tile_size=MAX_TILE_DIM):
+    def generate(
+        self,
+        aspect_ratio,
+        mp_size,
+        upscale_by,
+        model_type,
+        batch_size,
+        max_tile_size=MAX_TILE_DIM,
+        length=1,
+    ):
         target_area = MP_SIZE_TO_AREA.get(mp_size)
         if target_area is None:
             raise ValueError(
                 f"Unknown mp_size {mp_size!r}. Expected one of {', '.join(MP_SIZES)}."
             )
-        return self._build(aspect_ratio, target_area, upscale_by, model_type, batch_size, max_tile_size)
+        return self._build(
+            aspect_ratio, target_area, upscale_by, model_type, batch_size, max_tile_size, length
+        )
 
 
 class BobsLatentNodeAdvanced(_BobsLatentBase):
@@ -348,8 +442,9 @@ class BobsLatentNodeAdvanced(_BobsLatentBase):
     """
 
     DESCRIPTION = (
-        "Empty latent sized for FLUX / SDXL / SD3 / Qwen / Wan from an aspect ratio and a "
-        "continuous megapixel target, plus suggested tile dimensions for tiled upscaling."
+        "Empty latent sized for a wide range of image and video model families from an "
+        "aspect ratio and a continuous megapixel target, plus suggested tile dimensions "
+        "for tiled upscaling."
     )
 
     @classmethod
@@ -380,11 +475,26 @@ class BobsLatentNodeAdvanced(_BobsLatentBase):
         required.update(cls._shared_inputs())
         return {"required": required, "optional": cls._optional_inputs()}
 
-    def generate(self, aspect_ratio, mp_size_float, upscale_by, model_type, batch_size, max_tile_size=MAX_TILE_DIM):
+    def generate(
+        self,
+        aspect_ratio,
+        mp_size_float,
+        upscale_by,
+        model_type,
+        batch_size,
+        max_tile_size=MAX_TILE_DIM,
+        length=1,
+    ):
         if mp_size_float <= 0:
             raise ValueError(f"mp_size_float must be greater than zero, got {mp_size_float}.")
         return self._build(
-            aspect_ratio, mp_size_float * MP_BASE_AREA, upscale_by, model_type, batch_size, max_tile_size
+            aspect_ratio,
+            mp_size_float * MP_BASE_AREA,
+            upscale_by,
+            model_type,
+            batch_size,
+            max_tile_size,
+            length,
         )
 
 

--- a/Bobs_Latent_Optimizer.py
+++ b/Bobs_Latent_Optimizer.py
@@ -1,352 +1,399 @@
-# --- START OF FILE Bobs_Latent_Optimizer.py ---
+"""Bobs Latent Optimizer - empty latent generation with model-aware sizing.
 
-import torch
+Generates empty latents whose pixel dimensions are legal for the selected model
+family, and derives sensible tile dimensions for a downstream tiled upscaler.
+"""
+
+import logging
 import math
 
-def round_to_nearest_multiple(value, multiple):
-    """Rounds a value to the nearest multiple of 'multiple'."""
-    if multiple <= 0:
-        return value
-    return int(round(value / multiple) * multiple)
+import torch
+
+logger = logging.getLogger(__name__)
+
+# ComfyUI keeps freshly allocated latents on an "intermediate" device so they do
+# not pin VRAM before the sampler needs them. Fall back to CPU when the node is
+# imported outside of ComfyUI (tests, tooling).
+try:
+    import comfy.model_management as model_management
+except ImportError:
+    model_management = None
+
 
 MP_BASE_AREA = 1024 * 1024
 
-# --- BobsLatentNode ---
-class BobsLatentNode:
-    """
-    Generates an empty latent image optimized for various models (FLUX, SDXL, SD3, QWEN, WAN)
-    based on aspect ratio, approximate discrete megapixel size options, and batch size.
-    Calculates dimensions by rounding to the NEAREST multiple appropriate for the selected model.
-    Handles the correct number of latent channels (4 for most, 16 for FLUX).
-    Calculates tile dimensions for tiling of the *upscaled pixel output*
-    to help optimize tiled upscale times. Aims for a 2x2 grid (4 tiles) unless
-    individual tiles would exceed 2048x2048, in which case more tiles are used.
-    """
-    def __init__(self):
-        pass
+VAE_SCALE_FACTOR = 8
 
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "aspect_ratio": ("STRING", {"default": "1:1", "tooltip": "Target image aspect ratio (e.g., '1:1', '16:9', '3:2'). This determines the shape of the BASE latent image."}),
-                "mp_size": (["0.25", "0.5", "1", "1.25", "1.5", "1.75", "2", "2.5", "3", "4"], {"default": "1", "tooltip": "Approximate target megapixel area for the BASE latent image. These options map to common standard resolution areas (e.g., 1 is 1024x1024 area, 4 is 2048x2048 area)."}),
-                "upscale_by": ("FLOAT", {
-                    "default": 2.0,
-                    "min": 1.0,
-                    "max": 10.0,
-                    "step": .01,
-                    "tooltip": "Desired upscale factor for the FINAL output image. Used to calculate tiling dimensions in pixel space. Does NOT upscale the generated latent."
-                }),
-                "model_type": (["FLUX", "SDXL", "SD3", "QWEN", "WAN"], {"default": "FLUX", "tooltip": "Select model to set resolution rounding rules and latent channels (FLUX=16, QWEN=round to 28, others=4 channels & round to 64)."}),
-                "batch_size": ("INT", {"default": 1, "min": 1, "max": 64, "step": 1, "tooltip": "Number of latent images in the batch."})
-            }
-        }
+MAX_TILE_DIM = 2048
 
-    RETURN_TYPES = ("LATENT", "INT", "INT", "FLOAT")
-    RETURN_NAMES = ("latent", "tile_width", "tile_height", "upscale_by")
+# Per-model latent channel count and pixel alignment.
+#
+# `channels` is the channel count of the model's VAE: SDXL is the only 4-channel
+# family here. FLUX, SD3/3.5, Qwen-Image and Wan all use 16-channel VAEs.
+#
+# `align` must stay a multiple of VAE_SCALE_FACTOR so that
+# pixel_size // VAE_SCALE_FACTOR is exact and the reported pixel dimensions
+# actually describe the tensor we return.
+MODEL_SPECS = {
+    "FLUX": {"channels": 16, "align": 64},
+    "SDXL": {"channels": 4, "align": 64},
+    "SD3": {"channels": 16, "align": 64},
+    "QWEN": {"channels": 16, "align": 16},
+    "WAN": {"channels": 16, "align": 16},
+}
+
+MODEL_TYPES = list(MODEL_SPECS.keys())
+
+# Discrete area presets. These are approximate megapixel labels mapped to common
+# standard resolution areas rather than exact multiples of 1MP.
+MP_SIZE_TO_AREA = {
+    "0.25": 512 * 512,
+    "0.5": 768 * 768,
+    "1": 1024 * 1024,
+    "1.25": 1280 * 1024,
+    "1.5": 1440 * 1080,
+    "1.75": 1664 * 1088,
+    "2": 1920 * 1080,
+    "2.5": 1536 * 1536,
+    "3": 1792 * 1792,
+    "4": 2048 * 2048,
+}
+
+MP_SIZES = list(MP_SIZE_TO_AREA.keys())
+
+_ASPECT_SEPARATORS = (":", "/", "x", "X", ",")
+
+
+def round_to_nearest_multiple(value, multiple):
+    """Round `value` to the nearest positive multiple of `multiple`."""
+    if multiple <= 0:
+        return int(round(value))
+    return int(round(value / multiple)) * multiple
+
+
+def parse_aspect_ratio(aspect_ratio):
+    """Parse an aspect ratio string into a width/height multiplier.
+
+    Accepts "16:9", "16/9", "16x9", "16,9" and decimal components such as
+    "1.5:1". A bare number ("1.777") is treated as the ratio itself.
+    """
+    if isinstance(aspect_ratio, (int, float)):
+        parts = [str(aspect_ratio)]
+    else:
+        text = str(aspect_ratio).strip()
+        if not text:
+            raise ValueError("Aspect ratio is empty. Use a format like '1:1' or '16:9'.")
+        parts = [text]
+        for separator in _ASPECT_SEPARATORS:
+            if separator in text:
+                parts = text.split(separator)
+                break
+
+    try:
+        numbers = [float(part.strip()) for part in parts]
+    except ValueError:
+        raise ValueError(
+            f"Invalid aspect ratio: {aspect_ratio!r}. Use 'width:height' with numeric "
+            "components, for example '1:1', '16:9' or '3:2'."
+        )
+
+    if len(numbers) == 1:
+        ratio = numbers[0]
+    elif len(numbers) == 2:
+        width, height = numbers
+        if height == 0:
+            raise ValueError(
+                f"Invalid aspect ratio: {aspect_ratio!r}. The height component cannot be zero."
+            )
+        ratio = width / height
+    else:
+        raise ValueError(
+            f"Invalid aspect ratio: {aspect_ratio!r}. Expected two components, got {len(numbers)}."
+        )
+
+    if not math.isfinite(ratio) or ratio <= 0:
+        raise ValueError(
+            f"Invalid aspect ratio: {aspect_ratio!r}. The ratio must be a positive number."
+        )
+    return ratio
+
+
+def compute_base_dimensions(target_area, aspect_ratio_multiplier, align):
+    """Return (width, height) in pixels covering ~`target_area`, aligned to `align`.
+
+    Both dimensions are clamped to at least one full alignment step so tiny
+    megapixel targets cannot produce a zero-sized latent.
+    """
+    if target_area <= 0:
+        raise ValueError(f"Target area must be positive, got {target_area}.")
+
+    width = math.sqrt(target_area * aspect_ratio_multiplier)
+    height = width / aspect_ratio_multiplier
+
+    minimum = max(align, VAE_SCALE_FACTOR)
+    width = max(minimum, round_to_nearest_multiple(width, align))
+    height = max(minimum, round_to_nearest_multiple(height, align))
+    return width, height
+
+
+def compute_tile_dimensions(width, height, upscale_by, max_tile_dim=MAX_TILE_DIM):
+    """Suggest tile dimensions for the upscaled pixel output.
+
+    Aims for a 2x2 grid, adding tiles along an axis only when a 2x2 tile would
+    exceed `max_tile_dim`. Tile dimensions are aligned up to a multiple of
+    VAE_SCALE_FACTOR because tiled VAE/upscaler nodes expect that.
+
+    Returns (tile_width, tile_height, tiles_x, tiles_y).
+    """
+    upscaled_width = max(1, int(width * upscale_by))
+    upscaled_height = max(1, int(height * upscale_by))
+    max_tile_dim = max(VAE_SCALE_FACTOR, int(max_tile_dim))
+
+    def axis_tiles(total):
+        tiles = 2
+        if -(-total // tiles) > max_tile_dim:
+            tiles = -(-total // max_tile_dim)
+        return max(1, tiles)
+
+    tiles_x = axis_tiles(upscaled_width)
+    tiles_y = axis_tiles(upscaled_height)
+
+    def tile_size(total, tiles):
+        size = -(-total // tiles)
+        # Round the tile up to the VAE stride, but never past the whole image.
+        size = -(-size // VAE_SCALE_FACTOR) * VAE_SCALE_FACTOR
+        return max(VAE_SCALE_FACTOR, min(size, total))
+
+    return (
+        tile_size(upscaled_width, tiles_x),
+        tile_size(upscaled_height, tiles_y),
+        tiles_x,
+        tiles_y,
+    )
+
+
+def _latent_device():
+    if model_management is not None:
+        return model_management.intermediate_device()
+    return torch.device("cpu")
+
+
+class _BobsLatentBase:
+    """Shared sizing, tiling and tensor allocation for both node variants."""
+
+    RETURN_TYPES = ("LATENT", "INT", "INT", "FLOAT", "INT", "INT")
+    RETURN_NAMES = ("latent", "tile_width", "tile_height", "upscale_by", "width", "height")
+    OUTPUT_TOOLTIPS = (
+        "Empty latent batch sized for the selected model.",
+        "Suggested tile width for a tiled upscaler operating on the upscaled pixel output.",
+        "Suggested tile height for a tiled upscaler operating on the upscaled pixel output.",
+        "The upscale factor, passed through unchanged for convenience.",
+        "Base image width in pixels.",
+        "Base image height in pixels.",
+    )
     FUNCTION = "generate"
     CATEGORY = "latent/generate"
 
-    def generate(self, aspect_ratio, mp_size, upscale_by, model_type, batch_size):
-
-        # --- 1. Calculate Target BASE Pixel Dimensions ---
-        try:
-            ratio_w, ratio_h = map(int, aspect_ratio.split(":"))
-            if ratio_h == 0: # Prevent division by zero
-                 raise ValueError("Height ratio cannot be zero.")
-            aspect_ratio_multiplier = (ratio_w / ratio_h)
-        except ValueError as e:
-            raise ValueError(f"Invalid aspect ratio format: {aspect_ratio}. Please use the format 'x:y' where x and y are integers (e.g., '1:1', '16:9'). Detail: {e}")
-
-
-        mp_to_area = {
-            "0.25": 512 * 512,
-            "0.5": 768 * 768,
-            "1": 1024 * 1024,
-            "1.25": 1280 * 1024,
-            "1.5": 1440 * 1080,
-            "1.75": 1664 * 1088,
-            "2": 1920 * 1080,
-            "2.5": 1536 * 1536,
-            "3": 1792 * 1792,
-            "4": 2048 * 2048,
-        }
-
-        target_area = mp_to_area.get(mp_size, 1024 * 1024)
-
-        initial_target_width_float = math.sqrt(target_area * aspect_ratio_multiplier)
-        initial_target_height_float = initial_target_width_float / aspect_ratio_multiplier
-
-        # --- 2. Apply Model-Specific BASE Sizing and Get Latent Channels ---
-        vae_scale_factor = 8
-        
-        if model_type == "FLUX":
-            latent_channels = 16
-            target_width = round_to_nearest_multiple(initial_target_width_float, 64)
-            target_height = round_to_nearest_multiple(initial_target_height_float, 64)
-        
-        elif model_type == "QWEN":
-            latent_channels = 4
-            target_width = round_to_nearest_multiple(initial_target_width_float, 28)
-            target_height = round_to_nearest_multiple(initial_target_height_float, 28)
-            
-        elif model_type == "SDXL" or model_type == "WAN":
-            latent_channels = 4
-            target_width = round_to_nearest_multiple(initial_target_width_float, 64)
-            target_height = round_to_nearest_multiple(initial_target_height_float, 64)
-        
-        elif model_type == "SD3":
-            latent_channels = 4
-            # First, round to 64 as a base
-            temp_width = round_to_nearest_multiple(initial_target_width_float, 64)
-            temp_height = round_to_nearest_multiple(initial_target_height_float, 64)
-            
-            # Then apply SD3 specific scaling logic
-            target_area_sd3_ref = 1024 * 1024
-            current_area = temp_width * temp_height
-            if current_area > 0:
-                 scaling_factor = (target_area_sd3_ref / current_area) ** 0.5
-                 target_width = int(temp_width * scaling_factor)
-                 target_height = int(temp_height * scaling_factor)
-                 # And re-round to 64
-                 target_width = round_to_nearest_multiple(target_width, 64)
-                 target_height = round_to_nearest_multiple(target_height, 64)
-            else:
-                 print(f"Warning: Calculated base dimensions were zero after initial rounding, skipping SD3 scaling.")
-                 target_width = temp_width
-                 target_height = temp_height
-        
-        min_dim = 64
-        if target_width < min_dim:
-             print(f"Warning: Calculated base width was {target_width}. Clamping to minimum {min_dim}.")
-             target_width = min_dim
-        if target_height < min_dim:
-             print(f"Warning: Calculated base height was {target_height}. Clamping to minimum {min_dim}.")
-             target_height = min_dim
-
-        # --- 3. Generate Empty Latent Image at BASE Resolution with Correct Channels ---
-        latent_width = target_width // vae_scale_factor
-        latent_height = target_height // vae_scale_factor
-
-        try:
-            latent_tensor = torch.zeros([batch_size, latent_channels, latent_height, latent_width])
-            latent = {"samples": latent_tensor}
-        except Exception as e:
-             raise RuntimeError(f"Error creating empty latent tensor with shape [{batch_size}, {latent_channels}, {latent_height}, {latent_width}] for {model_type}: {e}")
-
-        print(f"Generated {model_type} base latent: Batch={batch_size}, Channels={latent_channels}, Latent Size=({latent_width}x{latent_height}), Base Pixel Size=({target_width}x{target_height})")
-
-        # --- 4. Calculate Tile Dimensions for Tiling of the FINAL Upscaled Pixel Output ---
-        upscaled_total_width = int(target_width * upscale_by)
-        upscaled_total_height = int(target_height * upscale_by)
-
-        MAX_TILE_DIM = 2048
-
-        num_tiles_w = 2
-        num_tiles_h = 2
-
-        hypothetical_tile_w_for_2x2 = (upscaled_total_width + num_tiles_w - 1) // num_tiles_w
-        hypothetical_tile_h_for_2x2 = (upscaled_total_height + num_tiles_h - 1) // num_tiles_h
-        
-        if hypothetical_tile_w_for_2x2 > MAX_TILE_DIM:
-            num_tiles_w = int(math.ceil(upscaled_total_width / MAX_TILE_DIM))
-        
-        if hypothetical_tile_h_for_2x2 > MAX_TILE_DIM:
-            num_tiles_h = int(math.ceil(upscaled_total_height / MAX_TILE_DIM))
-
-        if num_tiles_w < 1: num_tiles_w = 1
-        if num_tiles_h < 1: num_tiles_h = 1
-            
-        # Calculate final tile dimensions using integer ceiling division
-        tile_width = (upscaled_total_width + num_tiles_w - 1) // num_tiles_w
-        tile_height = (upscaled_total_height + num_tiles_h - 1) // num_tiles_h
-        
-        # Ensure tile dimensions are at least 1 (final safety clamp)
-        if tile_width <= 0:
-             print(f"Warning: Calculated tile width was {tile_width}. Clamping to minimum 1.")
-             tile_width = 1
-        if tile_height <= 0:
-             print(f"Warning: Calculated tile height was {tile_height}. Clamping to minimum 1.")
-             tile_height = 1
-        
-        print(f"Upscaled image size: {upscaled_total_width}x{upscaled_total_height}")
-        print(f"Tiling grid: {num_tiles_w}x{num_tiles_h} ({num_tiles_w * num_tiles_h} tiles)")
-        print(f"Calculated tile dimensions for upscaled pixel output (upscale_by {upscale_by}): {tile_width}x{tile_height}")
-
-        # --- 5. Return Outputs ---
-        return (
-            latent,
-            tile_width,
-            tile_height,
-            upscale_by
-        )
-
-# --- Advanced Node: BobsLatentNodeAdvanced ---
-class BobsLatentNodeAdvanced:
-    """
-    Generates an empty latent image optimized for various models (FLUX, SDXL, SD3, QWEN, WAN)
-    based on aspect ratio, a continuous float megapixel size, and batch size.
-    Calculates dimensions by rounding to the NEAREST multiple appropriate for the selected model.
-    Handles the correct number of latent channels (4 for most, 16 for FLUX).
-    Calculates tile dimensions for tiling of the *upscaled pixel output*
-    to help optimize tiled upscale times. Aims for a 2x2 grid (4 tiles) unless
-    individual tiles would exceed 2048x2048, in which case more tiles are used.
-    """
-    def __init__(self):
-        pass
-
-    @classmethod
-    def INPUT_TYPES(cls):
+    @staticmethod
+    def _shared_inputs():
         return {
-            "required": {
-                "aspect_ratio": ("STRING", {"default": "1:1", "tooltip": "Target image aspect ratio (e.g., '1:1', '16:9', '3:2'). This determines the shape of the BASE latent image."}),
-                "mp_size_float": ("FLOAT", {"default": 1.0, "min": 0.01, "max": 4.0, "step": 0.01, "display": "number", "tooltip": f"Target megapixel area (in millions of pixels, based on {int(MP_BASE_AREA/1000000)} MP = {MP_BASE_AREA} pixels) for the BASE latent image. Range 0.01 to 4.0 (4.0 is 2048x2048 area)."}),
-                "upscale_by": ("FLOAT", {
+            "upscale_by": (
+                "FLOAT",
+                {
                     "default": 2.0,
                     "min": 1.0,
                     "max": 10.0,
-                    "step": .01,
-                    "tooltip": "Desired upscale factor for the FINAL output image. Used to calculate tiling dimensions in pixel space. Does NOT upscale the generated latent."
-                }),
-                "model_type": (["FLUX", "SDXL", "SD3", "QWEN", "WAN"], {"default": "FLUX", "tooltip": "Select model to set resolution rounding rules and latent channels (FLUX=16, QWEN=round to 28, others=4 channels & round to 64)."}),
-                "batch_size": ("INT", {"default": 1, "min": 1, "max": 64, "step": 1, "tooltip": "Number of latent images in the batch."})
-            }
+                    "step": 0.01,
+                    "tooltip": (
+                        "Upscale factor for the FINAL output image. Used only to compute the "
+                        "tile dimensions; the generated latent is NOT upscaled."
+                    ),
+                },
+            ),
+            "model_type": (
+                MODEL_TYPES,
+                {
+                    "default": "FLUX",
+                    "tooltip": (
+                        "Model family. Sets latent channels (SDXL=4, FLUX/SD3/QWEN/WAN=16) and "
+                        "pixel alignment (64 for FLUX/SDXL/SD3, 16 for QWEN/WAN)."
+                    ),
+                },
+            ),
+            "batch_size": (
+                "INT",
+                {"default": 1, "min": 1, "max": 64, "step": 1, "tooltip": "Number of latents in the batch."},
+            ),
         }
 
-    RETURN_TYPES = ("LATENT", "INT", "INT", "FLOAT")
-    RETURN_NAMES = ("latent", "tile_width", "tile_height", "upscale_by")
-    FUNCTION = "generate"
-    CATEGORY = "latent/generate"
+    @staticmethod
+    def _optional_inputs():
+        return {
+            "max_tile_size": (
+                "INT",
+                {
+                    "default": MAX_TILE_DIM,
+                    "min": 256,
+                    "max": 8192,
+                    "step": 64,
+                    "tooltip": (
+                        "Largest tile edge allowed before the tile grid is subdivided further. "
+                        "Lower this if your upscaler runs out of VRAM."
+                    ),
+                },
+            ),
+        }
 
-    def generate(self, aspect_ratio, mp_size_float, upscale_by, model_type, batch_size):
+    def _build(self, aspect_ratio, target_area, upscale_by, model_type, batch_size, max_tile_size):
+        spec = MODEL_SPECS.get(model_type)
+        if spec is None:
+            raise ValueError(
+                f"Unknown model_type {model_type!r}. Expected one of {', '.join(MODEL_TYPES)}."
+            )
 
-        # --- 1. Calculate Target BASE Pixel Dimensions ---
-        try:
-            ratio_w, ratio_h = map(int, aspect_ratio.split(":"))
-            if ratio_h == 0: # Prevent division by zero
-                 raise ValueError("Height ratio cannot be zero.")
-            aspect_ratio_multiplier = (ratio_w / ratio_h)
-        except ValueError as e:
-            raise ValueError(f"Invalid aspect ratio format: {aspect_ratio}. Please use the format 'x:y' where x and y are integers (e.g., '1:1', '16:9'). Detail: {e}")
+        aspect_ratio_multiplier = parse_aspect_ratio(aspect_ratio)
+        width, height = compute_base_dimensions(target_area, aspect_ratio_multiplier, spec["align"])
 
-        target_area = mp_size_float * MP_BASE_AREA
-
-        initial_target_width_float = math.sqrt(target_area * aspect_ratio_multiplier)
-        initial_target_height_float = initial_target_width_float / aspect_ratio_multiplier
-
-        # --- 2. Apply Model-Specific BASE Sizing and Get Latent Channels ---
-        vae_scale_factor = 8
-        
-        if model_type == "FLUX":
-            latent_channels = 16
-            target_width = round_to_nearest_multiple(initial_target_width_float, 64)
-            target_height = round_to_nearest_multiple(initial_target_height_float, 64)
-        
-        elif model_type == "QWEN":
-            latent_channels = 4
-            target_width = round_to_nearest_multiple(initial_target_width_float, 28)
-            target_height = round_to_nearest_multiple(initial_target_height_float, 28)
-            
-        elif model_type == "SDXL" or model_type == "WAN":
-            latent_channels = 4
-            target_width = round_to_nearest_multiple(initial_target_width_float, 64)
-            target_height = round_to_nearest_multiple(initial_target_height_float, 64)
-        
-        elif model_type == "SD3":
-            latent_channels = 4
-            # First, round to 64 as a base
-            temp_width = round_to_nearest_multiple(initial_target_width_float, 64)
-            temp_height = round_to_nearest_multiple(initial_target_height_float, 64)
-            
-            # Then apply SD3 specific scaling logic
-            target_area_sd3_ref = 1024 * 1024
-            current_area = temp_width * temp_height
-            if current_area > 0:
-                 scaling_factor = (target_area_sd3_ref / current_area) ** 0.5
-                 target_width = int(temp_width * scaling_factor)
-                 target_height = int(temp_height * scaling_factor)
-                 # And re-round to 64
-                 target_width = round_to_nearest_multiple(target_width, 64)
-                 target_height = round_to_nearest_multiple(target_height, 64)
-            else:
-                 print(f"Warning: Calculated base dimensions were zero after initial rounding, skipping SD3 scaling.")
-                 target_width = temp_width
-                 target_height = temp_height
-
-        min_dim = 64
-        if target_width < min_dim:
-             print(f"Warning: Calculated base width was {target_width}. Clamping to minimum {min_dim}.")
-             target_width = min_dim
-        if target_height < min_dim:
-             print(f"Warning: Calculated base height was {target_height}. Clamping to minimum {min_dim}.")
-             target_height = min_dim
-
-        # --- 3. Generate Empty Latent Image at BASE Resolution with Correct Channels ---
-        latent_width = target_width // vae_scale_factor
-        latent_height = target_height // vae_scale_factor
+        latent_width = width // VAE_SCALE_FACTOR
+        latent_height = height // VAE_SCALE_FACTOR
+        channels = spec["channels"]
 
         try:
-            latent_tensor = torch.zeros([batch_size, latent_channels, latent_height, latent_width])
-            latent = {"samples": latent_tensor}
-        except Exception as e:
-             raise RuntimeError(f"Error creating empty latent tensor with shape [{batch_size}, {latent_channels}, {latent_height}, {latent_width}] for {model_type}: {e}")
+            samples = torch.zeros(
+                [batch_size, channels, latent_height, latent_width],
+                device=_latent_device(),
+            )
+        except Exception as error:
+            raise RuntimeError(
+                f"Could not allocate latent of shape "
+                f"[{batch_size}, {channels}, {latent_height}, {latent_width}] for {model_type}: {error}"
+            )
 
-        print(f"Generated {model_type} base latent: Batch={batch_size}, Channels={latent_channels}, Latent Size=({latent_width}x{latent_height}), Base Pixel Size=({target_width}x{target_height})")
-
-        # --- 4. Calculate Tile Dimensions for Tiling of the FINAL Upscaled Pixel Output ---
-        upscaled_total_width = int(target_width * upscale_by)
-        upscaled_total_height = int(target_height * upscale_by)
-
-        MAX_TILE_DIM = 2048
-
-        num_tiles_w = 2
-        num_tiles_h = 2
-
-        hypothetical_tile_w_for_2x2 = (upscaled_total_width + num_tiles_w - 1) // num_tiles_w
-        hypothetical_tile_h_for_2x2 = (upscaled_total_height + num_tiles_h - 1) // num_tiles_h
-        
-        if hypothetical_tile_w_for_2x2 > MAX_TILE_DIM:
-            num_tiles_w = int(math.ceil(upscaled_total_width / MAX_TILE_DIM))
-        
-        if hypothetical_tile_h_for_2x2 > MAX_TILE_DIM:
-            num_tiles_h = int(math.ceil(upscaled_total_height / MAX_TILE_DIM))
-        
-        if num_tiles_w < 1: num_tiles_w = 1
-        if num_tiles_h < 1: num_tiles_h = 1
-            
-        tile_width = (upscaled_total_width + num_tiles_w - 1) // num_tiles_w
-        tile_height = (upscaled_total_height + num_tiles_h - 1) // num_tiles_h
-        
-        if tile_width <= 0:
-             print(f"Warning: Calculated tile width was {tile_width}. Clamping to minimum 1.")
-             tile_width = 1
-        if tile_height <= 0:
-             print(f"Warning: Calculated tile height was {tile_height}. Clamping to minimum 1.")
-             tile_height = 1
-        
-        print(f"Upscaled image size: {upscaled_total_width}x{upscaled_total_height}")
-        print(f"Tiling grid: {num_tiles_w}x{num_tiles_h} ({num_tiles_w * num_tiles_h} tiles)")
-        print(f"Calculated tile dimensions for upscaled pixel output (upscale_by {upscale_by}): {tile_width}x{tile_height}")
-
-        # --- 5. Return Outputs ---
-        return (
-            latent,
-            tile_width,
-            tile_height,
-            upscale_by
+        tile_width, tile_height, tiles_x, tiles_y = compute_tile_dimensions(
+            width, height, upscale_by, max_tile_size
         )
 
-# --- NODE MAPPINGS ---
+        logger.info(
+            "Bobs Latent Optimizer: %s %dx%d px (latent %dx%d, %d channels, batch %d) -> "
+            "upscaled %dx%d px in a %dx%d grid of %dx%d tiles",
+            model_type,
+            width,
+            height,
+            latent_width,
+            latent_height,
+            channels,
+            batch_size,
+            int(width * upscale_by),
+            int(height * upscale_by),
+            tiles_x,
+            tiles_y,
+            tile_width,
+            tile_height,
+        )
+
+        return ({"samples": samples}, tile_width, tile_height, upscale_by, width, height)
+
+
+class BobsLatentNode(_BobsLatentBase):
+    """Generate an empty latent from an aspect ratio and a preset megapixel area.
+
+    Pixel dimensions are rounded to the nearest alignment step for the selected
+    model family, and the latent is allocated with that family's channel count.
+    Also returns tile dimensions for a downstream tiled upscaler, targeting a
+    2x2 grid unless that would push a tile past `max_tile_size`.
+    """
+
+    DESCRIPTION = (
+        "Empty latent sized for FLUX / SDXL / SD3 / Qwen / Wan from an aspect ratio and a "
+        "preset megapixel area, plus suggested tile dimensions for tiled upscaling."
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        required = {
+            "aspect_ratio": (
+                "STRING",
+                {
+                    "default": "1:1",
+                    "tooltip": "Aspect ratio of the base image, e.g. '1:1', '16:9', '3:2'.",
+                },
+            ),
+            "mp_size": (
+                MP_SIZES,
+                {
+                    "default": "1",
+                    "tooltip": (
+                        "Approximate megapixel area of the base image. Values map to common "
+                        "standard resolution areas (1 = 1024x1024, 4 = 2048x2048)."
+                    ),
+                },
+            ),
+        }
+        required.update(cls._shared_inputs())
+        return {"required": required, "optional": cls._optional_inputs()}
+
+    def generate(self, aspect_ratio, mp_size, upscale_by, model_type, batch_size, max_tile_size=MAX_TILE_DIM):
+        target_area = MP_SIZE_TO_AREA.get(mp_size)
+        if target_area is None:
+            raise ValueError(
+                f"Unknown mp_size {mp_size!r}. Expected one of {', '.join(MP_SIZES)}."
+            )
+        return self._build(aspect_ratio, target_area, upscale_by, model_type, batch_size, max_tile_size)
+
+
+class BobsLatentNodeAdvanced(_BobsLatentBase):
+    """Same as Bobs Latent Optimizer, but with a continuous megapixel target.
+
+    Use this when you want an exact area rather than one of the presets.
+    """
+
+    DESCRIPTION = (
+        "Empty latent sized for FLUX / SDXL / SD3 / Qwen / Wan from an aspect ratio and a "
+        "continuous megapixel target, plus suggested tile dimensions for tiled upscaling."
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        required = {
+            "aspect_ratio": (
+                "STRING",
+                {
+                    "default": "1:1",
+                    "tooltip": "Aspect ratio of the base image, e.g. '1:1', '16:9', '3:2'.",
+                },
+            ),
+            "mp_size_float": (
+                "FLOAT",
+                {
+                    "default": 1.0,
+                    "min": 0.01,
+                    "max": 16.0,
+                    "step": 0.01,
+                    "display": "number",
+                    "tooltip": (
+                        f"Target area in megapixels, where 1.0 = {MP_BASE_AREA} pixels "
+                        "(1024x1024). 4.0 is a 2048x2048 area."
+                    ),
+                },
+            ),
+        }
+        required.update(cls._shared_inputs())
+        return {"required": required, "optional": cls._optional_inputs()}
+
+    def generate(self, aspect_ratio, mp_size_float, upscale_by, model_type, batch_size, max_tile_size=MAX_TILE_DIM):
+        if mp_size_float <= 0:
+            raise ValueError(f"mp_size_float must be greater than zero, got {mp_size_float}.")
+        return self._build(
+            aspect_ratio, mp_size_float * MP_BASE_AREA, upscale_by, model_type, batch_size, max_tile_size
+        )
+
+
 NODE_CLASS_MAPPINGS = {
     "BobsLatentNode": BobsLatentNode,
-    "BobsLatentNodeAdvanced": BobsLatentNodeAdvanced
+    "BobsLatentNodeAdvanced": BobsLatentNodeAdvanced,
 }
 
-# --- NODE DISPLAY NAMES ---
 NODE_DISPLAY_NAME_MAPPINGS = {
     "BobsLatentNode": "Bobs Latent Optimizer",
-    "BobsLatentNodeAdvanced": "Bobs Latent Optimizer (Advanced)"
+    "BobsLatentNodeAdvanced": "Bobs Latent Optimizer (Advanced)",
 }
-
-# --- END OF FILE Bobs_Latent_Optimizer.py ---

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bobs Latent Optimizer for ComfyUI
 
-A pair of custom nodes for ComfyUI that generate empty latents sized correctly for FLUX, SDXL, SD3, Qwen-Image and Wan. You give them an aspect ratio and a target megapixel area; they work out pixel dimensions that are legal for the selected model family and allocate the latent with that family's channel count.
+A pair of custom nodes for ComfyUI that generate empty latents sized correctly for **23 model families** — SD1.5 through Flux2, Qwen-Image, HiDream, HunyuanImage, and video models like Wan, LTXV and Mochi. You give them an aspect ratio and a target megapixel area; they work out pixel dimensions that are legal for the selected model family and allocate the latent with that family's channel count, VAE downscale and rank.
 
 They also calculate **tile dimensions for upscaling workflows**, so you can feed sensible `tile_width` / `tile_height` values straight into a tiled upscaler (Ultimate SD Upscale, Tiled VAE Decode, etc.) instead of guessing.
 
@@ -11,9 +11,11 @@ They also calculate **tile dimensions for upscaling workflows**, so you can feed
     *   **Standard Node:** pick from a list of approximate megapixel areas (0.25MP … 4MP).
     *   **Advanced Node:** a continuous float for an exact target area.
 *   **Model-Specific Optimizations:**
-    *   Rounds base pixel dimensions to the nearest alignment step for the chosen model (64 for FLUX/SDXL/SD3, 16 for Qwen/Wan).
-    *   Allocates the correct latent channel count — 4 for SDXL, 16 for FLUX, SD3, Qwen-Image and Wan.
-    *   Guarantees pixel dimensions stay divisible by the VAE stride, so the reported size always matches the tensor.
+    *   Rounds base pixel dimensions to the nearest alignment step for the chosen model.
+    *   Allocates the correct latent channel count — anywhere from 3 (Chroma Radiance, pixel space) to 128 (Flux2, LTXV).
+    *   Applies the correct VAE downscale — 1x, 8x, 16x or 32x depending on the family.
+    *   Guarantees pixel dimensions stay divisible by that downscale, so the reported size always matches the tensor.
+*   **Video Model Support:** video families emit a proper 5-D latent (`[B, C, T, H, W]`) using ComfyUI's frame formula `((length - 1) // temporal_downscale) + 1`.
 *   **Batch Size Support:** generate batches of latents.
 *   **Optimized Tiling Calculation for Upscalers:**
     *   Targets a **2x2 grid (4 tiles)** for the upscaled image.
@@ -49,9 +51,10 @@ The nodes appear under the **latent/generate** category.
 *   **`mp_size` (list — Standard node):** approximate target megapixel area.
 *   **`mp_size_float` (FLOAT — Advanced node):** exact target megapixel area (`1.0` = 1024x1024 pixels).
 *   **`upscale_by` (FLOAT):** the upscale factor for your *final* image. Used to compute `tile_width` / `tile_height`. **This node does not perform the upscale.**
-*   **`model_type` (list):** `FLUX`, `SDXL`, `SD3`, `QWEN` or `WAN` — selects alignment and latent channels.
+*   **`model_type` (list):** the model family — selects latent channels, VAE downscale, alignment and rank. See the table below.
 *   **`batch_size` (INT):** number of latents in the batch.
 *   **`max_tile_size` (INT, optional):** largest tile edge before the grid subdivides further. Default 2048; lower it if your upscaler runs out of VRAM.
+*   **`length` (INT, optional):** number of video frames. Only used by video families; image families ignore it and log a warning.
 
 ### Outputs
 
@@ -64,15 +67,44 @@ The nodes appear under the **latent/generate** category.
 
 ### Model reference
 
-| `model_type` | Latent channels | Pixel alignment |
-| ------------ | --------------- | --------------- |
-| FLUX         | 16              | 64              |
-| SDXL         | 4               | 64              |
-| SD3 / SD3.5  | 16              | 64              |
-| QWEN         | 16              | 16              |
-| WAN          | 16              | 16              |
+Every row is taken from ComfyUI's own `comfy/latent_formats.py` (`latent_channels`, `latent_dimensions`, `spacial_downscale_ratio`, `temporal_downscale_ratio`) and cross-checked against the matching `Empty*Latent*` node, so the shapes match what the samplers actually expect.
 
-> **Note on WAN:** Wan is a video model and its samplers expect a 5-D latent with a temporal axis. These nodes emit a 4-D image latent, so the `WAN` option is useful for Wan-compatible *image-space* sizing and channel count, not as a drop-in replacement for a Wan video latent node.
+#### Image families — latent is `[B, C, H/s, W/s]`
+
+| `model_type`      | Channels | VAE downscale | Alignment | Covers |
+| ----------------- | -------- | ------------- | --------- | ------ |
+| `SD15`            | 4        | 8             | 64        | SD 1.5, SVD, Stable Zero123 |
+| `SD21`            | 4        | 8             | 64        | SD 2.0 / 2.1 |
+| `SDXL`            | 4        | 8             | 64        | SDXL, Playground v2.5, SSD-1B, Segmind Vega, KOALA |
+| `PIXART`          | 4        | 8             | 64        | PixArt-α, PixArt-Σ |
+| `AURAFLOW`        | 4        | 8             | 64        | AuraFlow |
+| `HUNYUAN_DIT`     | 4        | 8             | 64        | HunyuanDiT |
+| `SD3`             | 16       | 8             | 64        | SD3, SD3.5 |
+| `FLUX`            | 16       | 8             | 64        | FLUX.1 dev/schnell, Kontext, Inpaint |
+| `CHROMA`          | 16       | 8             | 64        | Chroma |
+| `HIDREAM`         | 16       | 8             | 64        | HiDream-I1 |
+| `LUMINA2`         | 16       | 8             | 64        | Lumina Image 2.0, Z-Image |
+| `OMNIGEN2`        | 16       | 8             | 64        | OmniGen2 |
+| `QWEN`            | 16       | 8             | 16        | Qwen-Image |
+| `COSMOS_PREDICT2` | 16       | 8             | 16        | Cosmos Predict2 (text-to-image) |
+| `FLUX2`           | 128      | 16            | 64        | FLUX.2 |
+| `HUNYUAN_IMAGE`   | 64       | 32            | 64        | HunyuanImage 2.1 |
+| `CHROMA_RADIANCE` | 3        | 1             | 16        | Chroma Radiance (pixel space — no VAE) |
+
+#### Video families — latent is `[B, C, T, H/s, W/s]`
+
+`T` is derived from the `length` input as `((length - 1) // temporal) + 1`.
+
+| `model_type`     | Channels | VAE downscale | Temporal | Alignment | Covers |
+| ---------------- | -------- | ------------- | -------- | --------- | ------ |
+| `WAN`            | 16       | 8             | 4        | 16        | Wan 2.1 (T2V, I2V, VACE, Camera, …) |
+| `WAN22`          | 48       | 16            | 4        | 32        | Wan 2.2 T2V |
+| `HUNYUAN_VIDEO`  | 16       | 8             | 4        | 16        | HunyuanVideo, I2V, Skyreels |
+| `COSMOS`         | 16       | 8             | 8        | 16        | Cosmos 1.0 T2V / I2V |
+| `MOCHI`          | 12       | 8             | 6        | 16        | Genmo Mochi |
+| `LTXV`           | 128      | 32            | 8        | 32        | LTX-Video |
+
+**Not included:** Stable Cascade needs *two* latents (stage C and stage B) from one node, which doesn't fit this node's single-`LATENT` output. Audio and 3D formats (StableAudio, Hunyuan3D, ACEStep) aren't image/video latents at all.
 
 ### Example Workflow
 
@@ -102,13 +134,21 @@ Rather than guessing tile sizes, the node derives them from your desired final r
 
 ## Development
 
-The sizing and tiling math is exposed as plain functions (`parse_aspect_ratio`, `compute_base_dimensions`, `compute_tile_dimensions`), and the test suite stubs `torch`, so it runs without a ComfyUI or PyTorch install:
+The sizing and tiling math is exposed as plain functions (`parse_aspect_ratio`, `compute_base_dimensions`, `compute_tile_dimensions`, `compute_latent_frames`), and the test suite stubs `torch`, so it runs without a ComfyUI or PyTorch install:
 
 ```
 python -m unittest discover -s tests -v
 ```
 
 ## Changelog
+
+### 1.4.0
+
+*   **Added 18 model families**, taking the total from 5 to 23. New image families: `SD15`, `SD21`, `PIXART`, `AURAFLOW`, `HUNYUAN_DIT`, `CHROMA`, `HIDREAM`, `LUMINA2`, `OMNIGEN2`, `COSMOS_PREDICT2`, `FLUX2`, `HUNYUAN_IMAGE`, `CHROMA_RADIANCE`. New video families: `WAN22`, `HUNYUAN_VIDEO`, `COSMOS`, `MOCHI`, `LTXV`.
+*   **Added proper video latent support.** Video families now emit a 5-D latent `[B, C, T, H, W]` using ComfyUI's frame formula, driven by a new optional `length` input. Previously there was no way to produce a usable video latent.
+*   **Added per-model VAE downscale.** The downscale factor was hardcoded to 8, which cannot express Flux2 (16x), HunyuanImage 2.1 (32x), LTXV (32x), Wan 2.2 (16x) or Chroma Radiance (pixel space, 1x).
+*   **Changed:** `WAN` now produces a 5-D latent instead of a 4-D one. The 4-D latent was the documented limitation in 1.3.0 and was not usable with Wan samplers — this is the fix, but it is a visible change if you were relying on the old shape.
+*   Every channel count, downscale and temporal ratio is now verified against ComfyUI's `latent_formats.py` by a test.
 
 ### 1.3.0
 

--- a/README.md
+++ b/README.md
@@ -1,83 +1,92 @@
 # Bobs Latent Optimizer for ComfyUI
 
-A set of custom nodes for ComfyUI designed to generate optimized empty latent images, ideal for models like FLUX, Qwen, SDXL, SD3 and WAN. These nodes help you easily define your desired aspect ratio and approximate image resolution (in megapixels) and will automatically calculate dimensions that are compatible with the selected model.
+A pair of custom nodes for ComfyUI that generate empty latents sized correctly for FLUX, SDXL, SD3, Qwen-Image and Wan. You give them an aspect ratio and a target megapixel area; they work out pixel dimensions that are legal for the selected model family and allocate the latent with that family's channel count.
 
-A key feature is the intelligent calculation of **tile dimensions for upscaling workflows**. The nodes aim to provide optimal tile sizes (width and height) for a subsequent tiled upscaler (like Ultimate SD Upscale, Tiled VAE Decode, etc.), helping to improve performance and manage VRAM usage during high-resolution upscales.
+They also calculate **tile dimensions for upscaling workflows**, so you can feed sensible `tile_width` / `tile_height` values straight into a tiled upscaler (Ultimate SD Upscale, Tiled VAE Decode, etc.) instead of guessing.
 
 ## Features
 
-*   **Aspect Ratio Control:** Easily define custom and common aspect ratios like "1:1", "16:9", "3:2", "13:19", "85:110", etc.
+*   **Aspect Ratio Control:** `1:1`, `16:9`, `3:2`, `13:19`, `85:110`, and so on. `16/9`, `16x9` and decimal components like `1.5:1` are accepted too.
 *   **Megapixel-Based Sizing:**
-    *   **Standard Node:** Choose from a predefined list of approximate megapixel areas (e.g., 0.5MP, 1MP, 4MP).
-    *   **Advanced Node:** Use a continuous float input for precise megapixel targets.
+    *   **Standard Node:** pick from a list of approximate megapixel areas (0.25MP … 4MP).
+    *   **Advanced Node:** a continuous float for an exact target area.
 *   **Model-Specific Optimizations:**
-    *   Automatically rounds base pixel dimensions to the nearest multiple of 64 for model compatibility.
-    *   Sets the correct number of latent channels (16 for FLUX, 4 for SDXL/SD3/Qwen/WAN).
-    *   Applies SD3-specific target area scaling logic if "SD3" model type is selected.
-*   **Batch Size Support:** Generate batches of latent images.
+    *   Rounds base pixel dimensions to the nearest alignment step for the chosen model (64 for FLUX/SDXL/SD3, 16 for Qwen/Wan).
+    *   Allocates the correct latent channel count — 4 for SDXL, 16 for FLUX, SD3, Qwen-Image and Wan.
+    *   Guarantees pixel dimensions stay divisible by the VAE stride, so the reported size always matches the tensor.
+*   **Batch Size Support:** generate batches of latents.
 *   **Optimized Tiling Calculation for Upscalers:**
-    *   Calculates `tile_width` and `tile_height` for a *subsequent* upscaling step.
-    *   Aims for a **2x2 grid (4 tiles)** for the upscaled image by default.
-    *   If a 2x2 grid would result in individual tiles larger than **2048x2048 pixels**, the number of tiles is increased (e.g., to 3x2, 2x3, 3x3 etc.) to ensure no single tile dimension exceeds 2048.
-    *   This provides sensible tile sizes to feed into tiled upscaler nodes, potentially speeding up generation and reducing VRAM strain.
-*   **Outputs Ready for Workflow:** Provides the generated latent, calculated tile dimensions, and the upscale factor for easy integration.
+    *   Targets a **2x2 grid (4 tiles)** for the upscaled image.
+    *   Subdivides further along an axis only when a 2x2 tile would exceed the tile cap (**2048px** by default, adjustable via `max_tile_size`).
+    *   Tile dimensions are rounded up to a multiple of 8 so tiled VAE nodes are happy.
+*   **Allocation on ComfyUI's intermediate device**, matching the behaviour of the built-in `EmptyLatentImage`.
 
 ## Nodes
 
 ### 1. Bobs Latent Optimizer (`BobsLatentNode`)
 
-The standard node for generating optimized latent images.
-
-*   **Key Difference:** Uses a dropdown menu (`mp_size`) with predefined approximate megapixel sizes (e.g., "1" for a 1024x1024 area, "4" for a 2048x2048 area).
+Uses a dropdown (`mp_size`) of predefined approximate megapixel areas — e.g. `"1"` for a 1024x1024 area, `"4"` for a 2048x2048 area.
 
 ### 2. Bobs Latent Optimizer (Advanced) (`BobsLatentNodeAdvanced`)
 
-The advanced version offering finer control over the target resolution.
-
-*   **Key Difference:** Uses a float input (`mp_size_float`) for specifying the target megapixel area directly (e.g., 1.0 for 1MP, 0.75 for 0.75MP).
+Uses a float (`mp_size_float`) for the target area directly, where `1.0` = 1048576 pixels.
 
 ## Installation
 
-1.  Navigate to your ComfyUI `custom_nodes` directory:
-    *   `cd ComfyUI/custom_nodes/`
-2.  Clone this repository:
-    *   `git clone https://github.com/BobsBlazed/Bobs_Latent_Optimizer.git`
+Install from the [ComfyUI Registry](https://registry.comfy.org/) via ComfyUI-Manager, or manually:
+
+1.  `cd ComfyUI/custom_nodes/`
+2.  `git clone https://github.com/BobsBlazed/Bobs_Latent_Optimizer.git`
 3.  Restart ComfyUI.
-    The nodes "Bobs Latent Optimizer" and "Bobs Latent Optimizer (Advanced)" should now be available in the "latent/generate" category.
+
+The nodes appear under the **latent/generate** category.
 
 ## Usage
 
-Both nodes share a similar set of inputs and outputs, with the main difference being how the target megapixel size is specified.
-
 ### Inputs
 
-*   **`aspect_ratio` (STRING):** The target aspect ratio for the base latent image (e.g., "1:1", "16:9", "4:3").
-*   **`mp_size` (STRING list - Standard Node only):** Approximate target megapixel area for the base latent image, chosen from a list.
-*   **`mp_size_float` (FLOAT - Advanced Node only):** Precise target megapixel area for the base latent image (e.g., 1.0 = 1024x1024 pixels).
-*   **`upscale_by` (FLOAT):** The desired upscale factor for the *final output image*. This value is **crucial** as it's used to calculate the `tile_width` and `tile_height` for a subsequent tiled upscaler. This node *does not* perform the upscale itself.
-*   **`model_type` (STRING list):** Select the target model (FLUX, SDXL, SD3) to apply appropriate rounding rules and latent channel counts.
-*   **`batch_size` (INT):** Number of latent images to generate in the batch.
+*   **`aspect_ratio` (STRING):** target aspect ratio for the base image, e.g. `"1:1"`, `"16:9"`, `"4:3"`.
+*   **`mp_size` (list — Standard node):** approximate target megapixel area.
+*   **`mp_size_float` (FLOAT — Advanced node):** exact target megapixel area (`1.0` = 1024x1024 pixels).
+*   **`upscale_by` (FLOAT):** the upscale factor for your *final* image. Used to compute `tile_width` / `tile_height`. **This node does not perform the upscale.**
+*   **`model_type` (list):** `FLUX`, `SDXL`, `SD3`, `QWEN` or `WAN` — selects alignment and latent channels.
+*   **`batch_size` (INT):** number of latents in the batch.
+*   **`max_tile_size` (INT, optional):** largest tile edge before the grid subdivides further. Default 2048; lower it if your upscaler runs out of VRAM.
 
 ### Outputs
 
-*   **`latent` (LATENT):** The generated empty latent image(s) as a dictionary (`{"samples": tensor}`).
-*   **`tile_width` (INT):** The calculated suggested width for each tile of the *upscaled pixel output*.
-*   **`tile_height` (INT):** The calculated suggested height for each tile of the *upscaled pixel output*.
-*   **`upscale_by` (FLOAT):** The input upscale factor, passed through for convenience in your workflow.
+*   **`latent` (LATENT):** the empty latent batch, as `{"samples": tensor}`.
+*   **`tile_width` (INT):** suggested tile width for the *upscaled pixel output*.
+*   **`tile_height` (INT):** suggested tile height for the *upscaled pixel output*.
+*   **`upscale_by` (FLOAT):** passed through unchanged.
+*   **`width` (INT):** base image width in pixels.
+*   **`height` (INT):** base image height in pixels.
+
+### Model reference
+
+| `model_type` | Latent channels | Pixel alignment |
+| ------------ | --------------- | --------------- |
+| FLUX         | 16              | 64              |
+| SDXL         | 4               | 64              |
+| SD3 / SD3.5  | 16              | 64              |
+| QWEN         | 16              | 16              |
+| WAN          | 16              | 16              |
+
+> **Note on WAN:** Wan is a video model and its samplers expect a 5-D latent with a temporal axis. These nodes emit a 4-D image latent, so the `WAN` option is useful for Wan-compatible *image-space* sizing and channel count, not as a drop-in replacement for a Wan video latent node.
 
 ### Example Workflow
 
-These nodes are typically used at the beginning of an image generation workflow, before the KSampler. The key is to connect the `tile_width` and `tile_height` outputs to a tiled upscaler node that you might use *after* your initial generation and VAE decode.
+These nodes sit at the start of a generation workflow, before the KSampler. Connect `tile_width` and `tile_height` to the tiled upscaler you use *after* your initial generation and VAE decode.
 
 ```
 [Bobs Latent Optimizer] ----> latent (to KSampler)
                          |
                          |---> tile_width  -----\
-                         |                     |
-                         |---> tile_height -----+--> [Your Tiled Upscaler Node] (e.g., Ultimate SD Upscale inputs: tile_width, tile_height)
-                         |                                   (or Tiled VAE Decode etc.)
+                         |                      |
+                         |---> tile_height -----+--> [Your Tiled Upscaler Node]
+                         |                                (Ultimate SD Upscale, Tiled VAE Decode, …)
                          |
-                         ----> upscale_by ------> (Potentially to your Tiled Upscaler Node if it takes a scale factor directly)
+                         ----> upscale_by ------> (if your upscaler takes a scale factor directly)
 
 [KSampler] --------------> VAE --------------> [Tiled Upscaler Node]
 (using latent from above)  (decode)             (using tile_width, tile_height from above)
@@ -85,20 +94,37 @@ These nodes are typically used at the beginning of an image generation workflow,
 
 **Why is this useful for tiling?**
 
-Instead of manually calculating or guessing tile sizes for your upscaler, this node provides sensible defaults based on your desired final resolution (`target_base_resolution * upscale_by`) and the 2048x2048 per-tile limit. This can prevent issues like:
-*   Tiles being too large, causing VRAM errors.
-*   Tiles being unnecessarily small, potentially leading to more processing overhead or seam issues if not handled well by the upscaler.
-*   Inconsistent tiling strategies.
+Rather than guessing tile sizes, the node derives them from your desired final resolution (`base_resolution * upscale_by`) and the per-tile cap. That avoids:
 
-By aiming for a 2x2 grid (4 tiles total) unless the image is very large, it strikes a balance for common upscaling scenarios.
+*   tiles large enough to cause VRAM errors,
+*   tiles unnecessarily small, adding processing overhead and seam risk,
+*   inconsistent tiling between workflows.
 
-## Benefits
+## Development
 
-*   **Simplified Resolution Setup:** No need to manually calculate pixel dimensions that are multiples of 64.
-*   **Model Compatibility:** Ensures your latent images are correctly sized and have the right channel count for FLUX, SDXL, or SD3.
-*   **Optimized Upscaling:** Provides intelligent tile dimensions for downstream tiled upscalers, potentially improving performance and VRAM management.
-*   **Consistent Workflows:** Standardizes how you define resolutions and prepare for tiled upscaling.
+The sizing and tiling math is exposed as plain functions (`parse_aspect_ratio`, `compute_base_dimensions`, `compute_tile_dimensions`), and the test suite stubs `torch`, so it runs without a ComfyUI or PyTorch install:
+
+```
+python -m unittest discover -s tests -v
+```
+
+## Changelog
+
+### 1.3.0
+
+*   **Fixed:** node display names never showed up in ComfyUI — the keys in `NODE_DISPLAY_NAME_MAPPINGS` did not match the class-mapping keys.
+*   **Fixed:** SD3, Qwen and Wan latents were allocated with 4 channels. All three use 16-channel VAEs, so those latents were unusable with their samplers.
+*   **Fixed:** Qwen rounded pixel dimensions to multiples of 28, which is not divisible by the VAE stride of 8 — the reported pixel size did not match the latent that was produced. Qwen now aligns to 16.
+*   **Fixed:** SD3 rescaled every result back to roughly 1MP, so `mp_size` / `mp_size_float` were silently ignored for that model.
+*   **Fixed:** negative or non-integer aspect ratios crashed with an opaque `math domain error` instead of a helpful message.
+*   **Added:** `width` and `height` outputs (appended, so existing workflows keep working).
+*   **Added:** optional `max_tile_size` input.
+*   **Added:** `16/9`, `16x9` and decimal aspect-ratio formats.
+*   **Changed:** tile dimensions are rounded up to a multiple of 8 and never exceed the image itself.
+*   **Changed:** latents are allocated on ComfyUI's intermediate device, matching `EmptyLatentImage`.
+*   **Changed:** the two node classes now share one implementation; output goes through `logging` instead of `print`.
+*   **Added:** unit test suite and a CI workflow.
 
 ## Contributing
 
-Contributions, issues, and feature requests are welcome! Please feel free to open an issue or submit a pull request.
+Contributions, issues, and feature requests are welcome — please open an issue or a pull request.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bobs Latent Optimizer for ComfyUI
 
-A pair of custom nodes for ComfyUI that generate empty latents sized correctly for **23 model families** — SD1.5 through Flux2, Qwen-Image, HiDream, HunyuanImage, and video models like Wan, LTXV and Mochi. You give them an aspect ratio and a target megapixel area; they work out pixel dimensions that are legal for the selected model family and allocate the latent with that family's channel count, VAE downscale and rank.
+A pair of custom nodes for ComfyUI that generate empty latents sized correctly for **30 model families** — SD1.5 through Flux2, Qwen-Image, HiDream, HunyuanImage, and video models like Wan, LTXV and Mochi. You give them an aspect ratio and a target megapixel area; they work out pixel dimensions that are legal for the selected model family and allocate the latent with that family's channel count, VAE downscale and rank.
 
 They also calculate **tile dimensions for upscaling workflows**, so you can feed sensible `tile_width` / `tile_height` values straight into a tiled upscaler (Ultimate SD Upscale, Tiled VAE Decode, etc.) instead of guessing.
 
@@ -87,24 +87,47 @@ Every row is taken from ComfyUI's own `comfy/latent_formats.py` (`latent_channel
 | `OMNIGEN2`        | 16       | 8             | 64        | OmniGen2 |
 | `QWEN`            | 16       | 8             | 16        | Qwen-Image |
 | `COSMOS_PREDICT2` | 16       | 8             | 16        | Cosmos Predict2 (text-to-image) |
-| `FLUX2`           | 128      | 16            | 64        | FLUX.2 |
+| `FLUX2`           | 128      | 16            | 64        | FLUX.2, Ideogram4, MageFlow, ErnieImage, Lens |
 | `HUNYUAN_IMAGE`   | 64       | 32            | 64        | HunyuanImage 2.1 |
-| `CHROMA_RADIANCE` | 3        | 1             | 16        | Chroma Radiance (pixel space — no VAE) |
+
+Pixel-space families have no VAE at all, so the "latent" *is* the image. Alignment of 16 matches the step on ComfyUI's own pixel-space latent node.
+
+| `model_type`      | Channels | VAE downscale | Alignment | Covers |
+| ----------------- | -------- | ------------- | --------- | ------ |
+| `CHROMA_RADIANCE` | 3        | 1             | 16        | Chroma Radiance |
+| `HIDREAM_O1`      | 3        | 1             | 16        | HiDream O1 (distinct from `HIDREAM`) |
+| `ZIMAGE_PIXEL`    | 3        | 1             | 16        | Z-Image pixel space |
+| `PIXELDIT`        | 3        | 1             | 16        | PixelDiT T2I, PiD |
 
 #### Video families — latent is `[B, C, T, H/s, W/s]`
 
 `T` is derived from the `length` input as `((length - 1) // temporal) + 1`.
 
-| `model_type`     | Channels | VAE downscale | Temporal | Alignment | Covers |
-| ---------------- | -------- | ------------- | -------- | --------- | ------ |
-| `WAN`            | 16       | 8             | 4        | 16        | Wan 2.1 (T2V, I2V, VACE, Camera, …) |
-| `WAN22`          | 48       | 16            | 4        | 32        | Wan 2.2 T2V |
-| `HUNYUAN_VIDEO`  | 16       | 8             | 4        | 16        | HunyuanVideo, I2V, Skyreels |
-| `COSMOS`         | 16       | 8             | 8        | 16        | Cosmos 1.0 T2V / I2V |
-| `MOCHI`          | 12       | 8             | 6        | 16        | Genmo Mochi |
-| `LTXV`           | 128      | 32            | 8        | 32        | LTX-Video |
+| `model_type`       | Channels | VAE downscale | Temporal | Alignment | Covers |
+| ------------------ | -------- | ------------- | -------- | --------- | ------ |
+| `WAN`              | 16       | 8             | 4        | 16        | Wan 2.1 (T2V, I2V, VACE, Camera, …), Krea2, JoyImage, Anima |
+| `WAN22`            | 48       | 16            | 4        | 32        | Wan 2.2 T2V |
+| `HUNYUAN_VIDEO`    | 16       | 8             | 4        | 16        | HunyuanVideo, I2V, Skyreels, Kandinsky5 |
+| `HUNYUAN_VIDEO_15` | 32       | 16            | 4        | 32        | HunyuanVideo 1.5, SR distilled |
+| `COSMOS`           | 16       | 8             | 8        | 16        | Cosmos 1.0 T2V / I2V |
+| `COGVIDEOX`        | 16       | 8             | 4        | 16        | CogVideoX T2V / I2V / Inpaint |
+| `MOCHI`            | 12       | 8             | 6        | 16        | Genmo Mochi |
+| `LTXV`             | 128      | 32            | 8        | 32        | LTX-Video, LTX-AV |
 
-**Not included:** Stable Cascade needs *two* latents (stage C and stage B) from one node, which doesn't fit this node's single-`LATENT` output. Audio and 3D formats (StableAudio, Hunyuan3D, ACEStep) aren't image/video latents at all.
+#### Shape-only families
+
+These two are included so their shapes are available, but **neither is normally driven from an empty latent** — selecting one logs a warning. SeedVR2 restores existing video (its preprocess node takes an `IMAGE`), and the HunyuanImage 2.1 refiner consumes the base model's latent.
+
+| `model_type`            | Channels | VAE downscale | Temporal | Alignment |
+| ----------------------- | -------- | ------------- | -------- | --------- |
+| `SEEDVR2`               | 16       | 8             | 1        | 16        |
+| `HUNYUAN_IMAGE_REFINER` | 64       | 8             | 1        | 16        |
+
+#### Two deliberate deviations from upstream
+
+`QWEN` and `COSMOS_PREDICT2` map to `latent_formats.Wan21`, which declares `latent_dimensions = 3` and `temporal_downscale_ratio = 4` — they inherit it because they share Wan's VAE. Both are still-image models, and ComfyUI's own Qwen workflows build their latent with `EmptySD3LatentImage`, which is 4-D. This node follows the workflow rather than the shared format and treats both as 2-D. The test suite keeps the verbatim upstream values and the override in separate tables, so the deviation stays visible rather than being absorbed into the "transcribed from ComfyUI" claim.
+
+**Not included:** Stable Cascade needs *two* latents (stage C and stage B) from one node, which doesn't fit this node's single-`LATENT` output. Audio and 3D formats (StableAudio, Hunyuan3D, ACEStep, TripoSplat) aren't image/video latents at all.
 
 ### Example Workflow
 
@@ -141,6 +164,15 @@ python -m unittest discover -s tests -v
 ```
 
 ## Changelog
+
+### 1.5.0
+
+*   **Added 7 more model families**, taking the total from 23 to 30 and closing the gap against ComfyUI `master`:
+    *   Pixel-space image: `HIDREAM_O1`, `ZIMAGE_PIXEL`, `PIXELDIT` (3 channels, no VAE downscale).
+    *   Video: `HUNYUAN_VIDEO_15` (32ch, 16×), `COGVIDEOX`.
+    *   Shape-only: `SEEDVR2` and `HUNYUAN_IMAGE_REFINER`, which are **not** empty-latent workflows — selecting either logs a warning explaining that the model consumes an existing image or latent.
+*   **Fixed a provenance overclaim in the test suite.** `COMFY_REFERENCE` was documented as transcribed from ComfyUI's `latent_formats.py`, but the `QWEN` and `COSMOS_PREDICT2` rows silently encoded a judgement call (treating them as 2-D despite `latent_formats.Wan21` declaring 3-D). The table now holds verbatim upstream values, with the deviation isolated in `INTENTIONAL_OVERRIDES` alongside its justification, plus a test asserting each override still genuinely deviates — so it becomes dead code to delete if upstream ever agrees. The node's behaviour is unchanged; only the claim about where the numbers came from is now accurate.
+*   **Documented which models each family covers.** Newer models that reuse an existing format (Ideogram4, MageFlow, ErnieImage and Lens on Flux2; Krea2, JoyImage and Anima on Wan21; LongCat and Kandinsky5Image on Flux) already worked but weren't discoverable — they're now named in the reference tables.
 
 ### 1.4.0
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,14 +1,3 @@
-from .Bobs_Latent_Optimizer import BobsLatentNode
-from .Bobs_Latent_Optimizer import BobsLatentNodeAdvanced
+from .Bobs_Latent_Optimizer import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
 
-NODE_CLASS_MAPPINGS = {
-    "BobsLatentNode": BobsLatentNode,
-    "BobsLatentNodeAdvanced": BobsLatentNodeAdvanced
-}
-
-NODE_DISPLAY_NAME_MAPPINGS = {
-    "Bobs-Latent-Optimizer": "Bobs Latent Optimizer",
-    "Bobs-Advanced-Latent-Optimizer": "Bobs Latent Optimizer (Advanced)"
-}
-
-print("✨ Bobs Latent Optimizer nodes loaded! ✨")
+__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "bobs_latent_optimizer"
-description = "This custom node for ComfyUI is designed to optimize latent generation for 23 model families, including FLUX, Flux2, SDXL, SD3, Qwen-Image, HiDream, Chroma, Lumina2, HunyuanImage, Wan, LTXV and Mochi. It provides flexible control over aspect ratios, megapixel sizes, video length and upscale factors, allowing users to dynamically create latents that fit specific tiling and resolution needs."
-version = "1.4.0"
+description = "This custom node for ComfyUI is designed to optimize latent generation across 30 image and video model families, including FLUX, Flux2, SDXL, SD3, Qwen-Image, HiDream, Chroma, Lumina2, HunyuanImage, Wan, HunyuanVideo, CogVideoX, LTXV and Mochi. It provides flexible control over aspect ratios, megapixel sizes, video length and upscale factors, allowing users to dynamically create latents that fit specific tiling and resolution needs."
+version = "1.5.0"
 license = {file = "LICENSE"}
 requires-python = ">=3.9"
 # torch is intentionally not declared: it is provided by the ComfyUI runtime and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,12 @@
 [project]
 name = "bobs_latent_optimizer"
 description = "This custom node for ComfyUI is designed to optimize latent generation for use with FLUX, Qwen, SDXL, SD3 and WAN. It provides flexible control over aspect ratios, megapixel sizes, and upscale factors, allowing users to dynamically create latents that fit specific tiling and resolution needs."
-version = "1.2.5"
+version = "1.3.0"
 license = {file = "LICENSE"}
+requires-python = ">=3.9"
+# torch is intentionally not declared: it is provided by the ComfyUI runtime and
+# pinning it here would fight with the user's existing install.
+dependencies = []
 
 [project.urls]
 Repository = "https://github.com/BobsBlazed/Bobs_Latent_Optimizer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "bobs_latent_optimizer"
-description = "This custom node for ComfyUI is designed to optimize latent generation for use with FLUX, Qwen, SDXL, SD3 and WAN. It provides flexible control over aspect ratios, megapixel sizes, and upscale factors, allowing users to dynamically create latents that fit specific tiling and resolution needs."
-version = "1.3.0"
+description = "This custom node for ComfyUI is designed to optimize latent generation for 23 model families, including FLUX, Flux2, SDXL, SD3, Qwen-Image, HiDream, Chroma, Lumina2, HunyuanImage, Wan, LTXV and Mochi. It provides flexible control over aspect ratios, megapixel sizes, video length and upscale factors, allowing users to dynamically create latents that fit specific tiling and resolution needs."
+version = "1.4.0"
 license = {file = "LICENSE"}
 requires-python = ">=3.9"
 # torch is intentionally not declared: it is provided by the ComfyUI runtime and

--- a/tests/test_latent_optimizer.py
+++ b/tests/test_latent_optimizer.py
@@ -31,10 +31,11 @@ import logging  # noqa: E402
 blo.logger.setLevel(logging.CRITICAL)
 
 
-# Ground truth transcribed from ComfyUI's comfy/latent_formats.py
-# (latent_channels / spacial_downscale_ratio / temporal_downscale_ratio /
-# latent_dimensions), cross-checked against the matching Empty*Latent* nodes.
-# Keyed by this node's model_type.
+# Ground truth transcribed VERBATIM from ComfyUI's comfy/latent_formats.py, as
+# (latent_channels, spacial_downscale_ratio, temporal_downscale_ratio,
+# latent_dimensions) for the format each model maps to in supported_models.py,
+# cross-checked against the matching Empty*Latent* node where one exists.
+# Keyed by this node's model_type. Nothing here is a judgement call.
 COMFY_REFERENCE = {
     "SD15": (4, 8, 1, 2),
     "SD21": (4, 8, 1, 2),
@@ -48,29 +49,80 @@ COMFY_REFERENCE = {
     "HIDREAM": (16, 8, 1, 2),
     "LUMINA2": (16, 8, 1, 2),
     "OMNIGEN2": (16, 8, 1, 2),
-    "QWEN": (16, 8, 1, 2),
-    "COSMOS_PREDICT2": (16, 8, 1, 2),
+    # QwenImage and CosmosT2IPredict2 map to latent_formats.Wan21, which is 3-D.
+    "QWEN": (16, 8, 4, 3),
+    "COSMOS_PREDICT2": (16, 8, 4, 3),
     "FLUX2": (128, 16, 1, 2),
     "HUNYUAN_IMAGE": (64, 32, 1, 2),
     "CHROMA_RADIANCE": (3, 1, 1, 2),
+    "HIDREAM_O1": (3, 1, 1, 2),
+    "ZIMAGE_PIXEL": (3, 1, 1, 2),
+    "PIXELDIT": (3, 1, 1, 2),
     "WAN": (16, 8, 4, 3),
     "WAN22": (48, 16, 4, 3),
     "HUNYUAN_VIDEO": (16, 8, 4, 3),
+    "HUNYUAN_VIDEO_15": (32, 16, 4, 3),
     "COSMOS": (16, 8, 8, 3),
+    "COGVIDEOX": (16, 8, 4, 3),
     "MOCHI": (12, 8, 6, 3),
     "LTXV": (128, 32, 8, 3),
+    "SEEDVR2": (16, 8, 1, 3),
+    "HUNYUAN_IMAGE_REFINER": (64, 8, 1, 3),
 }
+
+# Deliberate deviations from the table above, with the reason. Keeping these
+# separate is the point: it stops the reference table from quietly absorbing a
+# judgement call and pretending it came from upstream.
+#
+# Qwen-Image and Cosmos Predict2 (text-to-image) share Wan's VAE, so they
+# inherit latent_formats.Wan21 and its 3-D / temporal-4 declaration. Both are
+# still-image models: ComfyUI's own Qwen workflows build their latent with
+# EmptySD3LatentImage, which is 4-D. We follow the workflow, not the format.
+INTENTIONAL_OVERRIDES = {
+    "QWEN": {"temporal": 1, "dims": 2},
+    "COSMOS_PREDICT2": {"temporal": 1, "dims": 2},
+}
+
+# Models included for their shape only - they are never driven from an empty
+# latent, so selecting them warns.
+NOT_EMPTY_LATENT_WORKFLOWS = {"SEEDVR2", "HUNYUAN_IMAGE_REFINER"}
 
 
 class TestModelSpecs(unittest.TestCase):
     def test_specs_match_comfyui_latent_formats(self):
         self.assertEqual(set(blo.MODEL_SPECS), set(COMFY_REFERENCE))
         for model, (channels, vae_scale, temporal, dims) in COMFY_REFERENCE.items():
+            expected = {
+                "channels": channels,
+                "vae_scale": vae_scale,
+                "temporal": temporal,
+                "dims": dims,
+            }
+            expected.update(INTENTIONAL_OVERRIDES.get(model, {}))
             spec = blo.MODEL_SPECS[model]
-            self.assertEqual(spec["channels"], channels, model)
-            self.assertEqual(spec["vae_scale"], vae_scale, model)
-            self.assertEqual(spec["temporal"], temporal, model)
-            self.assertEqual(spec["dims"], dims, model)
+            for key, value in expected.items():
+                self.assertEqual(spec[key], value, f"{model}.{key}")
+
+    def test_overrides_actually_deviate_from_upstream(self):
+        # If upstream ever changes to agree with us, this override is dead code
+        # and should be deleted rather than left implying a conflict.
+        for model, override in INTENTIONAL_OVERRIDES.items():
+            channels, vae_scale, temporal, dims = COMFY_REFERENCE[model]
+            upstream = {
+                "channels": channels,
+                "vae_scale": vae_scale,
+                "temporal": temporal,
+                "dims": dims,
+            }
+            self.assertTrue(
+                any(upstream[k] != v for k, v in override.items()),
+                f"{model} override no longer deviates from upstream",
+            )
+
+    def test_shape_only_models_are_flagged(self):
+        for model, spec in blo.MODEL_SPECS.items():
+            expected = model not in NOT_EMPTY_LATENT_WORKFLOWS
+            self.assertEqual(spec.get("starts_from_empty", True), expected, model)
 
     def test_alignment_is_a_multiple_of_the_vae_scale(self):
         # This is the invariant that keeps width // vae_scale exact.
@@ -79,10 +131,12 @@ class TestModelSpecs(unittest.TestCase):
             self.assertGreater(spec["align"], 0, model)
 
     def test_video_model_list_is_derived_correctly(self):
-        self.assertEqual(
-            set(blo.VIDEO_MODEL_TYPES),
-            {m for m, (_, _, _, dims) in COMFY_REFERENCE.items() if dims == 3},
-        )
+        expected = set()
+        for model, (_, _, _, dims) in COMFY_REFERENCE.items():
+            dims = INTENTIONAL_OVERRIDES.get(model, {}).get("dims", dims)
+            if dims == 3:
+                expected.add(model)
+        self.assertEqual(set(blo.VIDEO_MODEL_TYPES), expected)
 
 
 class TestParseAspectRatio(unittest.TestCase):
@@ -231,14 +285,46 @@ class TestNodes(unittest.TestCase):
         self.assertEqual(len(latent["samples"].shape), 4)
         self.assertTrue(any("length=48 ignored" in line for line in captured.output))
 
-    def test_chroma_radiance_is_pixel_space(self):
+    def test_pixel_space_models_have_no_downscale(self):
         # vae_scale of 1 means the latent dims equal the pixel dims.
-        latent, _, _, _, width, height = blo.BobsLatentNode().generate(
-            "1:1", "1", 2.0, "CHROMA_RADIANCE", 1
-        )
-        _, channels, latent_h, latent_w = latent["samples"].shape
-        self.assertEqual(channels, 3)
-        self.assertEqual((latent_w, latent_h), (width, height))
+        node = blo.BobsLatentNode()
+        for model in ("CHROMA_RADIANCE", "HIDREAM_O1", "ZIMAGE_PIXEL", "PIXELDIT"):
+            latent, _, _, _, width, height = node.generate("1:1", "1", 2.0, model, 1)
+            _, channels, latent_h, latent_w = latent["samples"].shape
+            self.assertEqual(channels, 3, model)
+            self.assertEqual((latent_w, latent_h), (width, height), model)
+
+    def test_shape_only_models_warn_when_selected(self):
+        node = blo.BobsLatentNode()
+        for model in sorted(NOT_EMPTY_LATENT_WORKFLOWS):
+            with self.assertLogs(blo.logger, level="WARNING") as captured:
+                node.generate("1:1", "1", 2.0, model, 1)
+            self.assertTrue(
+                any("not normally driven from an empty latent" in line for line in captured.output),
+                model,
+            )
+
+    def test_ordinary_models_do_not_warn(self):
+        # assertNoLogs is 3.10+, and this suite supports 3.9, so capture manually.
+        records = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        handler = _Capture(level=logging.WARNING)
+        previous = blo.logger.level
+        blo.logger.setLevel(logging.WARNING)
+        blo.logger.addHandler(handler)
+        try:
+            node = blo.BobsLatentNode()
+            for model in ("FLUX", "SDXL", "WAN", "LTXV"):
+                node.generate("1:1", "1", 2.0, model, 1)
+        finally:
+            blo.logger.removeHandler(handler)
+            blo.logger.setLevel(previous)
+
+        self.assertEqual([r.getMessage() for r in records], [])
 
     def test_high_compression_models(self):
         node = blo.BobsLatentNode()

--- a/tests/test_latent_optimizer.py
+++ b/tests/test_latent_optimizer.py
@@ -1,0 +1,203 @@
+"""Tests for the pure sizing/tiling math and the node wiring.
+
+torch is stubbed so the suite runs without a ComfyUI install.
+"""
+
+import os
+import sys
+import types
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+if "torch" not in sys.modules:
+    torch_stub = types.ModuleType("torch")
+
+    class _FakeTensor:
+        def __init__(self, shape):
+            self.shape = tuple(shape)
+
+    torch_stub.zeros = lambda shape, device=None: _FakeTensor(shape)
+    torch_stub.device = lambda name: name
+    sys.modules["torch"] = torch_stub
+
+import Bobs_Latent_Optimizer as blo  # noqa: E402
+
+
+class TestParseAspectRatio(unittest.TestCase):
+    def test_common_formats(self):
+        for text in ("16:9", "16/9", "16x9", "16,9"):
+            self.assertAlmostEqual(blo.parse_aspect_ratio(text), 16 / 9, msg=text)
+
+    def test_decimal_components_and_bare_number(self):
+        self.assertAlmostEqual(blo.parse_aspect_ratio("1.5:1"), 1.5)
+        self.assertAlmostEqual(blo.parse_aspect_ratio("1.777"), 1.777)
+
+    def test_whitespace_is_tolerated(self):
+        self.assertAlmostEqual(blo.parse_aspect_ratio(" 3 : 2 "), 1.5)
+
+    def test_rejects_bad_input(self):
+        for text in ("", "1:0", "abc", "-16:9", "1:2:3", "0:1"):
+            with self.assertRaises(ValueError, msg=text):
+                blo.parse_aspect_ratio(text)
+
+
+class TestComputeBaseDimensions(unittest.TestCase):
+    def test_square_1mp_at_align_64(self):
+        self.assertEqual(blo.compute_base_dimensions(1024 * 1024, 1.0, 64), (1024, 1024))
+
+    def test_dimensions_are_aligned_and_divisible_by_vae_stride(self):
+        for model, spec in blo.MODEL_SPECS.items():
+            for ratio in (1.0, 16 / 9, 9 / 16, 3 / 2, 0.37):
+                width, height = blo.compute_base_dimensions(1024 * 1024, ratio, spec["align"])
+                self.assertEqual(width % spec["align"], 0, (model, ratio))
+                self.assertEqual(height % spec["align"], 0, (model, ratio))
+                self.assertEqual(width % blo.VAE_SCALE_FACTOR, 0, (model, ratio))
+                self.assertEqual(height % blo.VAE_SCALE_FACTOR, 0, (model, ratio))
+
+    def test_tiny_target_area_clamps_instead_of_collapsing(self):
+        width, height = blo.compute_base_dimensions(16, 1.0, 64)
+        self.assertEqual((width, height), (64, 64))
+
+    def test_area_is_approximately_preserved(self):
+        width, height = blo.compute_base_dimensions(4 * 1024 * 1024, 16 / 9, 64)
+        self.assertAlmostEqual(width / height, 16 / 9, delta=0.03)
+        self.assertAlmostEqual((width * height) / (4 * 1024 * 1024), 1.0, delta=0.05)
+
+    def test_rejects_non_positive_area(self):
+        with self.assertRaises(ValueError):
+            blo.compute_base_dimensions(0, 1.0, 64)
+
+
+class TestComputeTileDimensions(unittest.TestCase):
+    def test_default_grid_is_2x2(self):
+        tile_w, tile_h, tiles_x, tiles_y = blo.compute_tile_dimensions(1024, 1024, 2.0)
+        self.assertEqual((tiles_x, tiles_y), (2, 2))
+        self.assertEqual((tile_w, tile_h), (1024, 1024))
+
+    def test_grid_subdivides_when_tiles_would_exceed_the_cap(self):
+        tile_w, tile_h, tiles_x, tiles_y = blo.compute_tile_dimensions(2048, 2048, 4.0)
+        self.assertGreater(tiles_x, 2)
+        self.assertGreater(tiles_y, 2)
+        self.assertLessEqual(tile_w, blo.MAX_TILE_DIM)
+        self.assertLessEqual(tile_h, blo.MAX_TILE_DIM)
+
+    def test_tiles_cover_the_whole_upscaled_image(self):
+        for width, height, upscale in ((1024, 1024, 2.0), (1920, 1080, 3.5), (512, 768, 1.0)):
+            tile_w, tile_h, tiles_x, tiles_y = blo.compute_tile_dimensions(width, height, upscale)
+            self.assertGreaterEqual(tile_w * tiles_x, int(width * upscale))
+            self.assertGreaterEqual(tile_h * tiles_y, int(height * upscale))
+
+    def test_tiles_are_vae_stride_aligned(self):
+        tile_w, tile_h, _, _ = blo.compute_tile_dimensions(1080, 1080, 1.7)
+        self.assertEqual(tile_w % blo.VAE_SCALE_FACTOR, 0)
+        self.assertEqual(tile_h % blo.VAE_SCALE_FACTOR, 0)
+
+    def test_custom_cap_is_respected(self):
+        tile_w, tile_h, _, _ = blo.compute_tile_dimensions(2048, 2048, 2.0, max_tile_dim=512)
+        self.assertLessEqual(tile_w, 512)
+        self.assertLessEqual(tile_h, 512)
+
+    def test_tile_never_exceeds_the_image(self):
+        tile_w, tile_h, _, _ = blo.compute_tile_dimensions(64, 64, 1.0)
+        self.assertLessEqual(tile_w, 64)
+        self.assertLessEqual(tile_h, 64)
+
+
+class TestNodes(unittest.TestCase):
+    def test_latent_shape_matches_reported_pixel_size(self):
+        node = blo.BobsLatentNode()
+        for model in blo.MODEL_TYPES:
+            latent, _, _, _, width, height = node.generate("16:9", "1", 2.0, model, 2)
+            batch, channels, latent_h, latent_w = latent["samples"].shape
+            self.assertEqual(batch, 2, model)
+            self.assertEqual(channels, blo.MODEL_SPECS[model]["channels"], model)
+            self.assertEqual(latent_w * blo.VAE_SCALE_FACTOR, width, model)
+            self.assertEqual(latent_h * blo.VAE_SCALE_FACTOR, height, model)
+
+    def test_sdxl_is_the_only_four_channel_family(self):
+        node = blo.BobsLatentNode()
+        for model in blo.MODEL_TYPES:
+            latent, _, _, _, _, _ = node.generate("1:1", "1", 2.0, model, 1)
+            expected = 4 if model == "SDXL" else 16
+            self.assertEqual(latent["samples"].shape[1], expected, model)
+
+    def test_mp_size_is_honoured_for_every_model(self):
+        # Regression: SD3 used to rescale every result back to ~1MP.
+        node = blo.BobsLatentNode()
+        for model in blo.MODEL_TYPES:
+            _, _, _, _, small_w, small_h = node.generate("1:1", "1", 2.0, model, 1)
+            _, _, _, _, big_w, big_h = node.generate("1:1", "4", 2.0, model, 1)
+            self.assertGreater(big_w * big_h, small_w * small_h, model)
+            self.assertAlmostEqual((big_w * big_h) / (2048 * 2048), 1.0, delta=0.05, msg=model)
+
+    def test_upscale_by_passes_through(self):
+        node = blo.BobsLatentNode()
+        result = node.generate("1:1", "1", 3.25, "FLUX", 1)
+        self.assertAlmostEqual(result[3], 3.25)
+
+    def test_advanced_node_matches_preset_node_at_equal_area(self):
+        preset = blo.BobsLatentNode().generate("16:9", "1", 2.0, "FLUX", 1)
+        advanced = blo.BobsLatentNodeAdvanced().generate("16:9", 1.0, 2.0, "FLUX", 1)
+        self.assertEqual(preset[4:], advanced[4:])
+
+    def test_advanced_node_rejects_non_positive_area(self):
+        with self.assertRaises(ValueError):
+            blo.BobsLatentNodeAdvanced().generate("1:1", 0.0, 2.0, "FLUX", 1)
+
+    def test_unknown_selections_raise(self):
+        with self.assertRaises(ValueError):
+            blo.BobsLatentNode().generate("1:1", "1", 2.0, "NOPE", 1)
+        with self.assertRaises(ValueError):
+            blo.BobsLatentNode().generate("1:1", "7", 2.0, "FLUX", 1)
+
+    def test_max_tile_size_override(self):
+        node = blo.BobsLatentNode()
+        _, tile_w, tile_h, _, _, _ = node.generate("1:1", "4", 2.0, "FLUX", 1, max_tile_size=512)
+        self.assertLessEqual(tile_w, 512)
+        self.assertLessEqual(tile_h, 512)
+
+    def test_input_types_declare_every_generate_argument(self):
+        for cls in (blo.BobsLatentNode, blo.BobsLatentNodeAdvanced):
+            spec = cls.INPUT_TYPES()
+            declared = set(spec["required"]) | set(spec.get("optional", {}))
+            params = set(cls.generate.__code__.co_varnames[1:cls.generate.__code__.co_argcount])
+            self.assertEqual(declared, params, cls.__name__)
+
+    def test_return_metadata_is_consistent(self):
+        for cls in (blo.BobsLatentNode, blo.BobsLatentNodeAdvanced):
+            self.assertEqual(len(cls.RETURN_TYPES), len(cls.RETURN_NAMES), cls.__name__)
+            self.assertEqual(len(cls.RETURN_TYPES), len(cls.OUTPUT_TOOLTIPS), cls.__name__)
+            result = cls().generate("1:1", "1" if cls is blo.BobsLatentNode else 1.0, 2.0, "FLUX", 1)
+            self.assertEqual(len(result), len(cls.RETURN_TYPES), cls.__name__)
+
+    def test_display_names_cover_every_registered_node(self):
+        self.assertEqual(
+            set(blo.NODE_CLASS_MAPPINGS), set(blo.NODE_DISPLAY_NAME_MAPPINGS)
+        )
+
+    def test_package_exports_match_the_module(self):
+        # Import __init__.py the way ComfyUI does: as a package, so the relative
+        # import inside it is exercised.
+        import importlib.util
+
+        root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        spec = importlib.util.spec_from_file_location(
+            "bobs_latent_optimizer_pkg",
+            os.path.join(root, "__init__.py"),
+            submodule_search_locations=[root],
+        )
+        package = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = package
+        try:
+            spec.loader.exec_module(package)
+            self.assertEqual(set(package.NODE_CLASS_MAPPINGS), set(blo.NODE_CLASS_MAPPINGS))
+            self.assertEqual(
+                package.NODE_DISPLAY_NAME_MAPPINGS, blo.NODE_DISPLAY_NAME_MAPPINGS
+            )
+        finally:
+            sys.modules.pop(spec.name, None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_latent_optimizer.py
+++ b/tests/test_latent_optimizer.py
@@ -23,6 +23,67 @@ if "torch" not in sys.modules:
 
 import Bobs_Latent_Optimizer as blo  # noqa: E402
 
+# Several tests deliberately pass `length` to image models to prove it is
+# ignored; silence the resulting warnings. assertLogs re-enables the level it
+# needs for the test that actually asserts on the warning.
+import logging  # noqa: E402
+
+blo.logger.setLevel(logging.CRITICAL)
+
+
+# Ground truth transcribed from ComfyUI's comfy/latent_formats.py
+# (latent_channels / spacial_downscale_ratio / temporal_downscale_ratio /
+# latent_dimensions), cross-checked against the matching Empty*Latent* nodes.
+# Keyed by this node's model_type.
+COMFY_REFERENCE = {
+    "SD15": (4, 8, 1, 2),
+    "SD21": (4, 8, 1, 2),
+    "SDXL": (4, 8, 1, 2),
+    "PIXART": (4, 8, 1, 2),
+    "AURAFLOW": (4, 8, 1, 2),
+    "HUNYUAN_DIT": (4, 8, 1, 2),
+    "SD3": (16, 8, 1, 2),
+    "FLUX": (16, 8, 1, 2),
+    "CHROMA": (16, 8, 1, 2),
+    "HIDREAM": (16, 8, 1, 2),
+    "LUMINA2": (16, 8, 1, 2),
+    "OMNIGEN2": (16, 8, 1, 2),
+    "QWEN": (16, 8, 1, 2),
+    "COSMOS_PREDICT2": (16, 8, 1, 2),
+    "FLUX2": (128, 16, 1, 2),
+    "HUNYUAN_IMAGE": (64, 32, 1, 2),
+    "CHROMA_RADIANCE": (3, 1, 1, 2),
+    "WAN": (16, 8, 4, 3),
+    "WAN22": (48, 16, 4, 3),
+    "HUNYUAN_VIDEO": (16, 8, 4, 3),
+    "COSMOS": (16, 8, 8, 3),
+    "MOCHI": (12, 8, 6, 3),
+    "LTXV": (128, 32, 8, 3),
+}
+
+
+class TestModelSpecs(unittest.TestCase):
+    def test_specs_match_comfyui_latent_formats(self):
+        self.assertEqual(set(blo.MODEL_SPECS), set(COMFY_REFERENCE))
+        for model, (channels, vae_scale, temporal, dims) in COMFY_REFERENCE.items():
+            spec = blo.MODEL_SPECS[model]
+            self.assertEqual(spec["channels"], channels, model)
+            self.assertEqual(spec["vae_scale"], vae_scale, model)
+            self.assertEqual(spec["temporal"], temporal, model)
+            self.assertEqual(spec["dims"], dims, model)
+
+    def test_alignment_is_a_multiple_of_the_vae_scale(self):
+        # This is the invariant that keeps width // vae_scale exact.
+        for model, spec in blo.MODEL_SPECS.items():
+            self.assertEqual(spec["align"] % spec["vae_scale"], 0, model)
+            self.assertGreater(spec["align"], 0, model)
+
+    def test_video_model_list_is_derived_correctly(self):
+        self.assertEqual(
+            set(blo.VIDEO_MODEL_TYPES),
+            {m for m, (_, _, _, dims) in COMFY_REFERENCE.items() if dims == 3},
+        )
+
 
 class TestParseAspectRatio(unittest.TestCase):
     def test_common_formats(self):
@@ -46,27 +107,53 @@ class TestComputeBaseDimensions(unittest.TestCase):
     def test_square_1mp_at_align_64(self):
         self.assertEqual(blo.compute_base_dimensions(1024 * 1024, 1.0, 64), (1024, 1024))
 
-    def test_dimensions_are_aligned_and_divisible_by_vae_stride(self):
+    def test_dimensions_are_aligned_for_every_model(self):
         for model, spec in blo.MODEL_SPECS.items():
             for ratio in (1.0, 16 / 9, 9 / 16, 3 / 2, 0.37):
                 width, height = blo.compute_base_dimensions(1024 * 1024, ratio, spec["align"])
                 self.assertEqual(width % spec["align"], 0, (model, ratio))
                 self.assertEqual(height % spec["align"], 0, (model, ratio))
-                self.assertEqual(width % blo.VAE_SCALE_FACTOR, 0, (model, ratio))
-                self.assertEqual(height % blo.VAE_SCALE_FACTOR, 0, (model, ratio))
+                self.assertEqual(width % spec["vae_scale"], 0, (model, ratio))
+                self.assertEqual(height % spec["vae_scale"], 0, (model, ratio))
 
     def test_tiny_target_area_clamps_instead_of_collapsing(self):
-        width, height = blo.compute_base_dimensions(16, 1.0, 64)
-        self.assertEqual((width, height), (64, 64))
+        self.assertEqual(blo.compute_base_dimensions(16, 1.0, 64), (64, 64))
 
     def test_area_is_approximately_preserved(self):
         width, height = blo.compute_base_dimensions(4 * 1024 * 1024, 16 / 9, 64)
         self.assertAlmostEqual(width / height, 16 / 9, delta=0.03)
         self.assertAlmostEqual((width * height) / (4 * 1024 * 1024), 1.0, delta=0.05)
 
-    def test_rejects_non_positive_area(self):
+    def test_rejects_bad_arguments(self):
         with self.assertRaises(ValueError):
             blo.compute_base_dimensions(0, 1.0, 64)
+        with self.assertRaises(ValueError):
+            blo.compute_base_dimensions(1024, 1.0, 0)
+
+
+class TestComputeLatentFrames(unittest.TestCase):
+    def test_image_models_pass_length_through(self):
+        self.assertEqual(blo.compute_latent_frames(1, 1), 1)
+        self.assertEqual(blo.compute_latent_frames(17, 1), 17)
+
+    def test_matches_comfyui_formula(self):
+        # ComfyUI: ((length - 1) // temporal) + 1
+        for temporal in (4, 6, 8):
+            for length in (1, 2, 5, 17, 33, 121):
+                self.assertEqual(
+                    blo.compute_latent_frames(length, temporal),
+                    ((length - 1) // temporal) + 1,
+                    (temporal, length),
+                )
+
+    def test_wan_reference_values(self):
+        # 81 frames is the common Wan 2.1 default -> 21 latent frames.
+        self.assertEqual(blo.compute_latent_frames(81, 4), 21)
+        self.assertEqual(blo.compute_latent_frames(1, 4), 1)
+
+    def test_length_is_clamped_to_at_least_one(self):
+        self.assertEqual(blo.compute_latent_frames(0, 4), 1)
+        self.assertEqual(blo.compute_latent_frames(-5, 4), 1)
 
 
 class TestComputeTileDimensions(unittest.TestCase):
@@ -88,10 +175,10 @@ class TestComputeTileDimensions(unittest.TestCase):
             self.assertGreaterEqual(tile_w * tiles_x, int(width * upscale))
             self.assertGreaterEqual(tile_h * tiles_y, int(height * upscale))
 
-    def test_tiles_are_vae_stride_aligned(self):
+    def test_tiles_are_stride_aligned(self):
         tile_w, tile_h, _, _ = blo.compute_tile_dimensions(1080, 1080, 1.7)
-        self.assertEqual(tile_w % blo.VAE_SCALE_FACTOR, 0)
-        self.assertEqual(tile_h % blo.VAE_SCALE_FACTOR, 0)
+        self.assertEqual(tile_w % blo.TILE_ALIGN, 0)
+        self.assertEqual(tile_h % blo.TILE_ALIGN, 0)
 
     def test_custom_cap_is_respected(self):
         tile_w, tile_h, _, _ = blo.compute_tile_dimensions(2048, 2048, 2.0, max_tile_dim=512)
@@ -107,20 +194,64 @@ class TestComputeTileDimensions(unittest.TestCase):
 class TestNodes(unittest.TestCase):
     def test_latent_shape_matches_reported_pixel_size(self):
         node = blo.BobsLatentNode()
-        for model in blo.MODEL_TYPES:
-            latent, _, _, _, width, height = node.generate("16:9", "1", 2.0, model, 2)
-            batch, channels, latent_h, latent_w = latent["samples"].shape
-            self.assertEqual(batch, 2, model)
-            self.assertEqual(channels, blo.MODEL_SPECS[model]["channels"], model)
-            self.assertEqual(latent_w * blo.VAE_SCALE_FACTOR, width, model)
-            self.assertEqual(latent_h * blo.VAE_SCALE_FACTOR, height, model)
+        for model, spec in blo.MODEL_SPECS.items():
+            latent, _, _, _, width, height = node.generate("16:9", "1", 2.0, model, 2, length=17)
+            shape = latent["samples"].shape
+            self.assertEqual(shape[0], 2, model)
+            self.assertEqual(shape[1], spec["channels"], model)
+            latent_h, latent_w = shape[-2], shape[-1]
+            self.assertEqual(latent_w * spec["vae_scale"], width, model)
+            self.assertEqual(latent_h * spec["vae_scale"], height, model)
 
-    def test_sdxl_is_the_only_four_channel_family(self):
+    def test_latent_rank_matches_the_model_family(self):
         node = blo.BobsLatentNode()
-        for model in blo.MODEL_TYPES:
-            latent, _, _, _, _, _ = node.generate("1:1", "1", 2.0, model, 1)
-            expected = 4 if model == "SDXL" else 16
-            self.assertEqual(latent["samples"].shape[1], expected, model)
+        for model, spec in blo.MODEL_SPECS.items():
+            latent, _, _, _, _, _ = node.generate("1:1", "1", 2.0, model, 1, length=17)
+            expected_rank = 5 if spec["dims"] == 3 else 4
+            self.assertEqual(len(latent["samples"].shape), expected_rank, model)
+
+    def test_video_models_use_the_comfyui_frame_formula(self):
+        node = blo.BobsLatentNode()
+        for model in blo.VIDEO_MODEL_TYPES:
+            temporal = blo.MODEL_SPECS[model]["temporal"]
+            for length in (1, 17, 81):
+                latent, _, _, _, _, _ = node.generate(
+                    "1:1", "1", 2.0, model, 1, length=length
+                )
+                self.assertEqual(
+                    latent["samples"].shape[2],
+                    ((length - 1) // temporal) + 1,
+                    (model, length),
+                )
+
+    def test_image_models_ignore_length_and_warn(self):
+        node = blo.BobsLatentNode()
+        with self.assertLogs(blo.logger, level="WARNING") as captured:
+            latent, _, _, _, _, _ = node.generate("1:1", "1", 2.0, "FLUX", 1, length=48)
+        self.assertEqual(len(latent["samples"].shape), 4)
+        self.assertTrue(any("length=48 ignored" in line for line in captured.output))
+
+    def test_chroma_radiance_is_pixel_space(self):
+        # vae_scale of 1 means the latent dims equal the pixel dims.
+        latent, _, _, _, width, height = blo.BobsLatentNode().generate(
+            "1:1", "1", 2.0, "CHROMA_RADIANCE", 1
+        )
+        _, channels, latent_h, latent_w = latent["samples"].shape
+        self.assertEqual(channels, 3)
+        self.assertEqual((latent_w, latent_h), (width, height))
+
+    def test_high_compression_models(self):
+        node = blo.BobsLatentNode()
+        # HunyuanImage 2.1: 64 channels at 32x downscale.
+        latent, _, _, _, width, height = node.generate("1:1", "1", 2.0, "HUNYUAN_IMAGE", 1)
+        _, channels, latent_h, latent_w = latent["samples"].shape
+        self.assertEqual(channels, 64)
+        self.assertEqual((latent_w, latent_h), (width // 32, height // 32))
+        # Flux2: 128 channels at 16x downscale.
+        latent, _, _, _, width, height = node.generate("1:1", "1", 2.0, "FLUX2", 1)
+        _, channels, latent_h, latent_w = latent["samples"].shape
+        self.assertEqual(channels, 128)
+        self.assertEqual((latent_w, latent_h), (width // 16, height // 16))
 
     def test_mp_size_is_honoured_for_every_model(self):
         # Regression: SD3 used to rescale every result back to ~1MP.
@@ -132,14 +263,19 @@ class TestNodes(unittest.TestCase):
             self.assertAlmostEqual((big_w * big_h) / (2048 * 2048), 1.0, delta=0.05, msg=model)
 
     def test_upscale_by_passes_through(self):
-        node = blo.BobsLatentNode()
-        result = node.generate("1:1", "1", 3.25, "FLUX", 1)
+        result = blo.BobsLatentNode().generate("1:1", "1", 3.25, "FLUX", 1)
         self.assertAlmostEqual(result[3], 3.25)
 
     def test_advanced_node_matches_preset_node_at_equal_area(self):
         preset = blo.BobsLatentNode().generate("16:9", "1", 2.0, "FLUX", 1)
         advanced = blo.BobsLatentNodeAdvanced().generate("16:9", 1.0, 2.0, "FLUX", 1)
         self.assertEqual(preset[4:], advanced[4:])
+
+    def test_advanced_node_supports_video_models(self):
+        latent, _, _, _, _, _ = blo.BobsLatentNodeAdvanced().generate(
+            "16:9", 1.0, 2.0, "WAN", 1, length=81
+        )
+        self.assertEqual(latent["samples"].shape[1:3], (16, 21))
 
     def test_advanced_node_rejects_non_positive_area(self):
         with self.assertRaises(ValueError):
@@ -152,8 +288,9 @@ class TestNodes(unittest.TestCase):
             blo.BobsLatentNode().generate("1:1", "7", 2.0, "FLUX", 1)
 
     def test_max_tile_size_override(self):
-        node = blo.BobsLatentNode()
-        _, tile_w, tile_h, _, _, _ = node.generate("1:1", "4", 2.0, "FLUX", 1, max_tile_size=512)
+        _, tile_w, tile_h, _, _, _ = blo.BobsLatentNode().generate(
+            "1:1", "4", 2.0, "FLUX", 1, max_tile_size=512
+        )
         self.assertLessEqual(tile_w, 512)
         self.assertLessEqual(tile_h, 512)
 
@@ -164,6 +301,16 @@ class TestNodes(unittest.TestCase):
             params = set(cls.generate.__code__.co_varnames[1:cls.generate.__code__.co_argcount])
             self.assertEqual(declared, params, cls.__name__)
 
+    def test_model_dropdown_lists_every_spec(self):
+        for cls in (blo.BobsLatentNode, blo.BobsLatentNodeAdvanced):
+            choices = cls.INPUT_TYPES()["required"]["model_type"][0]
+            self.assertEqual(list(choices), list(blo.MODEL_SPECS), cls.__name__)
+
+    def test_default_model_is_still_flux(self):
+        for cls in (blo.BobsLatentNode, blo.BobsLatentNodeAdvanced):
+            opts = cls.INPUT_TYPES()["required"]["model_type"][1]
+            self.assertEqual(opts["default"], "FLUX", cls.__name__)
+
     def test_return_metadata_is_consistent(self):
         for cls in (blo.BobsLatentNode, blo.BobsLatentNodeAdvanced):
             self.assertEqual(len(cls.RETURN_TYPES), len(cls.RETURN_NAMES), cls.__name__)
@@ -172,9 +319,7 @@ class TestNodes(unittest.TestCase):
             self.assertEqual(len(result), len(cls.RETURN_TYPES), cls.__name__)
 
     def test_display_names_cover_every_registered_node(self):
-        self.assertEqual(
-            set(blo.NODE_CLASS_MAPPINGS), set(blo.NODE_DISPLAY_NAME_MAPPINGS)
-        )
+        self.assertEqual(set(blo.NODE_CLASS_MAPPINGS), set(blo.NODE_DISPLAY_NAME_MAPPINGS))
 
     def test_package_exports_match_the_module(self):
         # Import __init__.py the way ComfyUI does: as a package, so the relative


### PR DESCRIPTION
## Summary

Three commits, ending at **v1.5.0**. Fixes five correctness bugs in the latent sizing, expands `model_type` from 5 families to **30**, adds proper video latent support, and adds a test suite.

---

## Commit 1 — correctness fixes (v1.3.0)

**Display names never applied.** `__init__.py` keyed `NODE_DISPLAY_NAME_MAPPINGS` on `"Bobs-Latent-Optimizer"` / `"Bobs-Advanced-Latent-Optimizer"`, but `NODE_CLASS_MAPPINGS` keys are `"BobsLatentNode"` / `"BobsLatentNodeAdvanced"`. ComfyUI matches the two dicts by key, so it fell back to raw class names in the node menu.

**Wrong latent channel count for SD3, Qwen and Wan.** All three were hardcoded to 4 channels; all three use 16-channel VAEs. Confirmed against `supported_models.py`, where `QwenImage.latent_format = latent_formats.Wan21` (16ch). Only SDXL is 4-channel.

**Qwen alignment broke the pixel↔latent invariant.** Qwen rounded to multiples of 28, not divisible by the VAE stride of 8, so `target_width // 8` truncated — a 1036px width produced a 1032px latent while logging 1036.

**SD3 silently ignored `mp_size`.** The SD3 branch rescaled back toward a hardcoded 1024×1024 reference area, so selecting 4MP produced a ~1MP latent.

**Aspect ratio crashes.** `map(int, ...)` rejected `"1.5:1"`, and a negative ratio slipped past the `try` to fail inside `math.sqrt` with a bare `math domain error`.

Also: deduplicated the two ~95% identical node classes, added `width`/`height` outputs (appended, so indices 0–3 are unchanged and saved workflows keep working), added optional `max_tile_size`, accepted `16/9`/`16x9`/decimal ratios, aligned tile dims to the upscaler stride, moved allocation to `comfy.model_management.intermediate_device()`, swapped `print` for `logging`.

## Commit 2 — 18 new families + video support (v1.4.0)

Two structural changes were required:

- **Per-model VAE downscale.** It was hardcoded to 8, which can't express Flux2 and Wan 2.2 (16×), HunyuanImage 2.1 and LTXV (32×), or pixel-space models (1×).
- **5-D latents for video.** Video families emit `[B, C, T, H, W]` using ComfyUI's frame formula `((length - 1) // temporal) + 1`, driven by a new optional `length` input. Image families ignore `length` and log a warning rather than silently dropping it.

## Commit 3 — remaining 7 families + provenance fix (v1.5.0)

Closes the gap against ComfyUI `master` (audited: 40 of 47 model classes were already covered).

- **Pixel-space image:** `HIDREAM_O1`, `ZIMAGE_PIXEL`, `PIXELDIT` — 3 channels, no VAE downscale, so the latent *is* the image. Alignment of 16 matches the `step` on ComfyUI's own pixel-space latent node.
- **Video:** `HUNYUAN_VIDEO_15` (32ch, 16× spatial, verified against `nodes_hunyuan.py`) and `COGVIDEOX`.
- **Shape-only:** `SEEDVR2` and `HUNYUAN_IMAGE_REFINER` are flagged `starts_from_empty=False`. Neither is driven from an empty latent — SeedVR2 restores existing video (its preprocess node takes an `IMAGE`) and the HunyuanImage 2.1 refiner consumes the base model's latent. Selecting either logs a warning rather than silently returning a zero tensor no sampler wants as a starting point.

**Provenance fix.** `COMFY_REFERENCE` was documented as transcribed from `latent_formats.py`, but the `QWEN` and `COSMOS_PREDICT2` rows quietly encoded a judgement call: both map to `latent_formats.Wan21`, which declares `latent_dimensions = 3` and `temporal_downscale_ratio = 4`, yet both are still-image models and ComfyUI's own Qwen workflows use `EmptySD3LatentImage`, which is 4-D. The reference table now holds verbatim upstream values, with the deviation isolated in `INTENTIONAL_OVERRIDES` alongside its justification, plus a test asserting each override still genuinely deviates — so it becomes deletable dead code if upstream ever agrees. Node behaviour is unchanged; only the claim about where the numbers came from is now accurate.

**Discoverability.** Newer models that reuse an existing format already worked but weren't findable; the reference tables now name them (Ideogram4, MageFlow, ErnieImage, Lens on Flux2; Krea2, JoyImage, Anima on Wan21; LongCat, Kandinsky5Image on Flux).

---

## Behaviour changes to be aware of

- **`WAN` now emits a 5-D latent instead of 4-D.** The 4-D shape was not usable with Wan samplers, so this is the fix — but it's visible if you were relying on the old shape.
- **`SD3` and `QWEN` outputs change** (channel count, and Qwen's alignment 28 → 16). **FLUX and SDXL are unchanged.**
- All five original `model_type` values still exist, so no saved workflow fails to load.

## Not included

Stable Cascade needs *two* latents (stage C + stage B) from one node, which doesn't fit a single `LATENT` output. Audio and 3D formats (StableAudio, Hunyuan3D, ACEStep, TripoSplat) aren't image/video latents.

## Testing

45 unit tests. `torch` is stubbed, so the suite needs no ComfyUI or PyTorch install:

```
python -m unittest discover -s tests -v
```

Coverage includes the spec table vs. ComfyUI's verbatim values, the alignment-divides-downscale invariant, latent rank per family, the frame formula against ComfyUI's, pixel↔latent consistency across all 30 families, the shape-only warnings, the SD3 `mp_size` regression, and `INPUT_TYPES` matching each `generate` signature. CI runs it on Python 3.9 and 3.12 (the no-warning assertion avoids `assertNoLogs`, which is 3.10+).