### PR TITLE
Only publish to the Comfy registry from main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,22 @@
 name: Publish to Comfy registry
 on:
+  # workflow_dispatch accepts any ref, so the guard step below is what actually
+  # restricts publishing to main. Keeping the manual trigger is still useful for
+  # re-running a publish that failed for a transient reason.
   workflow_dispatch:
   push:
     branches:
       - main
-      - master
     paths:
       - "pyproject.toml"
 
 permissions:
   issues: write
+
+concurrency:
+  # Never let two publishes race for the same version number.
+  group: publish-comfy-registry
+  cancel-in-progress: false
 
 jobs:
   publish-node:
@@ -17,6 +24,18 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'BobsBlazed' }}
     steps:
+      - name: Refuse to publish from a non-default branch
+        # Publishing from a feature branch ships code that is not on main and
+        # burns the version number, so the later push-triggered run on main
+        # fails with "The node version already exists". Fail loudly and early
+        # rather than skipping the job, so a mis-targeted dispatch can never be
+        # mistaken for a successful publish.
+        if: github.ref != 'refs/heads/main'
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          echo "::error::Refusing to publish from '$REF_NAME'. The Comfy registry should only ever receive code that is on main. Merge first, then publish from main."
+          exit 1
       - name: Check out code
         uses: actions/checkout@v4
       - name: Publish Custom Node


### PR DESCRIPTION
## Summary

Closes the hole that produced the failed publish run on the v1.5.0 merge commit.

The `push` trigger was already restricted to `main`, but **`workflow_dispatch` accepts any ref**. A manual dispatch could therefore publish from a feature branch — shipping code that isn't on `main` and burning the version number, so the later push-triggered run on `main` fails with:

```
Failed to publish node version: 400 {"message":"The node version already exists"}
```

That's exactly what happened on [run 30327346391](https://github.com/BobsBlazed/Bobs_Latent_Optimizer/actions/runs/30327346391).

## Changes

- **Guard step** that fails when `github.ref != 'refs/heads/main'`. It fails *loudly* rather than skipping the job — a skipped job reads as "fine" in the Actions list, and for a publish the worst outcome is being unsure whether it shipped. The ref is passed via `env:` rather than interpolated into the shell.
- **Kept `workflow_dispatch`**, since re-running a publish that failed for a transient reason is genuinely useful. It just now only works from `main`.
- **Dropped `master`** from the push branches — the default branch is `main`, and a push to `master` would be rejected by the guard anyway, so leaving it would only produce confusing red runs.
- **Added a concurrency group** so two publishes can't race for the same version number.

## Effect

| Trigger | Before | After |
| --- | --- | --- |
| Push to `main` touching `pyproject.toml` | publishes | publishes |
| Manual dispatch from `main` | publishes | publishes |
| Manual dispatch from a branch | **publishes** | fails with a clear message |
| Push to `master` | publishes | trigger removed |

## Testing

No node code changed, so behaviour is unaffected — the 45-case suite still passes locally. I verified the YAML parses and that the guard is attached to the first step with the right condition; the trigger paths themselves can only be exercised by an actual dispatch, which is the thing this PR restricts.

`pyproject.toml` is unchanged, so **merging this will not trigger a publish** — the version stays at 1.5.0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbDZTWCvSqbXEX3GHJkSXw)_