### PR TITLE
Fix aspect-ratio comma ambiguity, add a resolution ceiling, warn on clamps (v1.5.1)

### DIFF
--- a/Bobs_Latent_Optimizer.py
+++ b/Bobs_Latent_Optimizer.py
@@ -30,6 +30,12 @@ MP_BASE_AREA = 1024 * 1024
 
 MAX_TILE_DIM = 2048
 
+# Mirrors MAX_RESOLUTION in ComfyUI's nodes.py. Every built-in latent node caps
+# its width/height widgets at this, so emitting anything larger produces a
+# latent that fails later - in the sampler or VAE decode - a long way from the
+# aspect ratio that actually caused it.
+MAX_DIMENSION = 16384
+
 # Model table.
 #
 #   channels  - latent channel count (latent_formats.latent_channels)
@@ -122,7 +128,10 @@ MP_SIZES = list(MP_SIZE_TO_AREA.keys())
 
 TILE_ALIGN = 8
 
-_ASPECT_SEPARATORS = (":", "/", "x", "X", ",")
+# "," is deliberately NOT a separator. In decimal-comma locales "1,5" means 1.5,
+# and treating the comma as a separator would silently read that as 1:5 = 0.2 -
+# a 7.5x wrong aspect ratio with no error. Rejecting it is the safer default.
+_ASPECT_SEPARATORS = (":", "/", "x", "X")
 
 
 def round_to_nearest_multiple(value, multiple):
@@ -135,8 +144,9 @@ def round_to_nearest_multiple(value, multiple):
 def parse_aspect_ratio(aspect_ratio):
     """Parse an aspect ratio string into a width/height multiplier.
 
-    Accepts "16:9", "16/9", "16x9", "16,9" and decimal components such as
-    "1.5:1". A bare number ("1.777") is treated as the ratio itself.
+    Accepts "16:9", "16/9", "16x9" and decimal components such as "1.5:1".
+    A bare number ("1.777") is treated as the ratio itself. A comma is not a
+    separator - see _ASPECT_SEPARATORS.
     """
     if isinstance(aspect_ratio, (int, float)):
         parts = [str(aspect_ratio)]
@@ -179,22 +189,56 @@ def parse_aspect_ratio(aspect_ratio):
     return ratio
 
 
-def compute_base_dimensions(target_area, aspect_ratio_multiplier, align):
+def compute_base_dimensions(target_area, aspect_ratio_multiplier, align, max_dim=MAX_DIMENSION):
     """Return (width, height) in pixels covering ~`target_area`, aligned to `align`.
 
-    Both dimensions are clamped to at least one full alignment step so tiny
-    megapixel targets cannot produce a zero-sized latent.
+    Dimensions are held between one full alignment step and `max_dim` (ComfyUI's
+    resolution ceiling). Both bounds distort the requested aspect ratio or area,
+    so each one warns when it bites rather than adjusting the result silently.
     """
     if target_area <= 0:
         raise ValueError(f"Target area must be positive, got {target_area}.")
     if align <= 0:
         raise ValueError(f"Alignment must be positive, got {align}.")
 
+    ceiling = (int(max_dim) // align) * align
+    if ceiling < align:
+        raise ValueError(
+            f"max_dim ({max_dim}) is smaller than one alignment step ({align})."
+        )
+
     width = math.sqrt(target_area * aspect_ratio_multiplier)
     height = width / aspect_ratio_multiplier
 
-    width = max(align, round_to_nearest_multiple(width, align))
-    height = max(align, round_to_nearest_multiple(height, align))
+    # Scale down before aligning so the aspect ratio survives the ceiling; only
+    # then clamp, which can still distort it when the other side is at the floor.
+    overshoot = max(width / ceiling, height / ceiling, 1.0)
+    if overshoot > 1.0:
+        logger.warning(
+            "Bobs Latent Optimizer: %.0fx%.0f px exceeds the %d px limit; scaling down "
+            "by %.2fx. The latent will be smaller than the megapixel target you asked for.",
+            width,
+            height,
+            ceiling,
+            overshoot,
+        )
+        width /= overshoot
+        height /= overshoot
+
+    aligned_width = round_to_nearest_multiple(width, align)
+    aligned_height = round_to_nearest_multiple(height, align)
+
+    if aligned_width < align or aligned_height < align:
+        logger.warning(
+            "Bobs Latent Optimizer: %dx%d px is below the %d px minimum for this model; "
+            "raising it. The aspect ratio will not match what you asked for.",
+            aligned_width,
+            aligned_height,
+            align,
+        )
+
+    width = min(ceiling, max(align, aligned_width))
+    height = min(ceiling, max(align, aligned_height))
     return width, height
 
 
@@ -249,6 +293,19 @@ def _latent_device():
     if model_management is not None:
         return model_management.intermediate_device()
     return torch.device("cpu")
+
+
+def _latent_dtype():
+    """Intermediate dtype, or None when it should not be passed.
+
+    ComfyUI's image latent nodes (EmptyLatentImage, EmptySD3LatentImage) pass
+    dtype=intermediate_dtype(); its video latent nodes (Wan, Hunyuan, Mochi,
+    LTXV) pass only device. We follow that split per model family rather than
+    applying one rule to both.
+    """
+    if model_management is None:
+        return None
+    return model_management.intermediate_dtype()
 
 
 class _BobsLatentBase:
@@ -378,8 +435,14 @@ class _BobsLatentBase:
                 )
             shape = [batch_size, channels, latent_height, latent_width]
 
+        allocate_kwargs = {"device": _latent_device()}
+        if spec["dims"] == 2:
+            dtype = _latent_dtype()
+            if dtype is not None:
+                allocate_kwargs["dtype"] = dtype
+
         try:
-            samples = torch.zeros(shape, device=_latent_device())
+            samples = torch.zeros(shape, **allocate_kwargs)
         except Exception as error:
             raise RuntimeError(
                 f"Could not allocate latent of shape {shape} for {model_type}: {error}"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ They also calculate **tile dimensions for upscaling workflows**, so you can feed
 
 ## Features
 
-*   **Aspect Ratio Control:** `1:1`, `16:9`, `3:2`, `13:19`, `85:110`, and so on. `16/9`, `16x9` and decimal components like `1.5:1` are accepted too.
+*   **Aspect Ratio Control:** `1:1`, `16:9`, `3:2`, `13:19`, `85:110`, and so on. `16/9`, `16x9` and decimal components like `1.5:1` are accepted too. A comma is deliberately rejected — `1,5` is a decimal in many locales, so guessing would risk silently reading it as `1:5`.
 *   **Megapixel-Based Sizing:**
     *   **Standard Node:** pick from a list of approximate megapixel areas (0.25MP … 4MP).
     *   **Advanced Node:** a continuous float for an exact target area.
@@ -164,6 +164,16 @@ python -m unittest discover -s tests -v
 ```
 
 ## Changelog
+
+### 1.5.1
+
+Fixes from a review of the 1.3.0–1.5.0 work. No shape changes — `FLUX 16:9 @1MP` is still `1344x768`, and every model's channel count, downscale and rank are untouched.
+
+*   **Fixed a silent wrong answer in aspect-ratio parsing.** `,` was treated as a separator, so in decimal-comma locales `1,5` (meaning 1.5) was read as `1:5` = 0.2 — a 7.5× wrong ratio with no error. Before 1.3.0 this raised a clear `ValueError`; the comma is now rejected again. **If you were relying on `16,9`, use `16:9`.**
+*   **Fixed dimensions exceeding ComfyUI's resolution limit.** There was no upper bound, so an extreme aspect ratio could emit sizes far past `MAX_RESOLUTION` (16384) — `1000:1` at 1MP produced 32384px wide. That allocates a small latent but fails much later, in the sampler or VAE decode, a long way from the aspect ratio that caused it. Dimensions are now scaled to fit the ceiling with the aspect ratio preserved where possible.
+*   **Fixed silent clamping.** Both the minimum and the new maximum distort the requested ratio or area, so each now warns. The pre-1.3.0 code warned on the minimum clamp and the rewrite had dropped it.
+*   **Fixed a fidelity gap against `EmptyLatentImage`.** Image families now allocate with `dtype=comfy.model_management.intermediate_dtype()`, matching `EmptyLatentImage` and `EmptySD3LatentImage`. Video families still pass only `device`, matching ComfyUI's video latent nodes.
+*   Tests grow from 45 to 52, covering the resolution ceiling, both clamp warnings, comma rejection, and the dtype split — the gaps that let the two clamping bugs through.
 
 ### 1.5.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "bobs_latent_optimizer"
 description = "This custom node for ComfyUI is designed to optimize latent generation across 30 image and video model families, including FLUX, Flux2, SDXL, SD3, Qwen-Image, HiDream, Chroma, Lumina2, HunyuanImage, Wan, HunyuanVideo, CogVideoX, LTXV and Mochi. It provides flexible control over aspect ratios, megapixel sizes, video length and upscale factors, allowing users to dynamically create latents that fit specific tiling and resolution needs."
-version = "1.5.0"
+version = "1.5.1"
 license = {file = "LICENSE"}
 requires-python = ">=3.9"
 # torch is intentionally not declared: it is provided by the ComfyUI runtime and

--- a/tests/test_latent_optimizer.py
+++ b/tests/test_latent_optimizer.py
@@ -14,10 +14,21 @@ if "torch" not in sys.modules:
     torch_stub = types.ModuleType("torch")
 
     class _FakeTensor:
-        def __init__(self, shape):
+        def __init__(self, shape, device=None, dtype=None):
             self.shape = tuple(shape)
+            self.device = device
+            # Sentinel so tests can tell "dtype was not passed" from "passed None".
+            self.dtype_was_passed = dtype is not _MISSING
+            self.dtype = None if dtype is _MISSING else dtype
 
-    torch_stub.zeros = lambda shape, device=None: _FakeTensor(shape)
+    class _Missing:
+        pass
+
+    _MISSING = _Missing()
+
+    torch_stub.zeros = lambda shape, device=None, dtype=_MISSING: _FakeTensor(
+        shape, device, dtype
+    )
     torch_stub.device = lambda name: name
     sys.modules["torch"] = torch_stub
 
@@ -141,7 +152,7 @@ class TestModelSpecs(unittest.TestCase):
 
 class TestParseAspectRatio(unittest.TestCase):
     def test_common_formats(self):
-        for text in ("16:9", "16/9", "16x9", "16,9"):
+        for text in ("16:9", "16/9", "16x9", "16X9"):
             self.assertAlmostEqual(blo.parse_aspect_ratio(text), 16 / 9, msg=text)
 
     def test_decimal_components_and_bare_number(self):
@@ -153,6 +164,14 @@ class TestParseAspectRatio(unittest.TestCase):
 
     def test_rejects_bad_input(self):
         for text in ("", "1:0", "abc", "-16:9", "1:2:3", "0:1"):
+            with self.assertRaises(ValueError, msg=text):
+                blo.parse_aspect_ratio(text)
+
+    def test_comma_is_rejected_rather_than_silently_misread(self):
+        # Regression: "," used to be a separator, so a decimal-comma locale
+        # typing "1,5" (meaning 1.5) silently got 1:5 = 0.2 instead. An error is
+        # the only safe answer when the input is genuinely ambiguous.
+        for text in ("1,5", "16,9"):
             with self.assertRaises(ValueError, msg=text):
                 blo.parse_aspect_ratio(text)
 
@@ -183,6 +202,62 @@ class TestComputeBaseDimensions(unittest.TestCase):
             blo.compute_base_dimensions(0, 1.0, 64)
         with self.assertRaises(ValueError):
             blo.compute_base_dimensions(1024, 1.0, 0)
+        with self.assertRaises(ValueError):
+            # max_dim below one alignment step has no valid answer.
+            blo.compute_base_dimensions(1024 * 1024, 1.0, 64, max_dim=32)
+
+    def test_never_exceeds_comfyui_resolution_limit(self):
+        # ComfyUI caps width/height at MAX_RESOLUTION (16384); anything larger
+        # blows up later in the sampler or VAE decode, far from the cause.
+        for model, spec in blo.MODEL_SPECS.items():
+            for ratio in ("100:1", "1000:1", "1:1000"):
+                multiplier = blo.parse_aspect_ratio(ratio)
+                for area in (1024 * 1024, 16 * 1024 * 1024):
+                    width, height = blo.compute_base_dimensions(
+                        area, multiplier, spec["align"]
+                    )
+                    self.assertLessEqual(width, blo.MAX_DIMENSION, (model, ratio))
+                    self.assertLessEqual(height, blo.MAX_DIMENSION, (model, ratio))
+                    self.assertEqual(width % spec["align"], 0, (model, ratio))
+                    self.assertEqual(height % spec["align"], 0, (model, ratio))
+
+    def test_ceiling_scaling_preserves_the_ratio_when_it_can(self):
+        # Only the width is over the limit here, so the ratio should survive.
+        multiplier = blo.parse_aspect_ratio("4:1")
+        width, height = blo.compute_base_dimensions(64 * 1024 * 1024, multiplier, 64)
+        self.assertLessEqual(width, blo.MAX_DIMENSION)
+        self.assertAlmostEqual(width / height, 4.0, delta=0.05)
+
+    def test_hitting_the_ceiling_warns(self):
+        with self.assertLogs(blo.logger, level="WARNING") as captured:
+            blo.compute_base_dimensions(16 * 1024 * 1024, 1000.0, 64)
+        self.assertTrue(any("exceeds the" in line for line in captured.output))
+
+    def test_hitting_the_floor_warns(self):
+        with self.assertLogs(blo.logger, level="WARNING") as captured:
+            blo.compute_base_dimensions(1024, 1000.0, 64)
+        self.assertTrue(any("below the" in line for line in captured.output))
+
+    def test_ordinary_sizes_do_not_warn(self):
+        records = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        handler = _Capture(level=logging.WARNING)
+        previous = blo.logger.level
+        blo.logger.setLevel(logging.WARNING)
+        blo.logger.addHandler(handler)
+        try:
+            for ratio in (1.0, 16 / 9, 9 / 16, 3 / 2, 2 / 3):
+                for area in (512 * 512, 1024 * 1024, 2048 * 2048):
+                    blo.compute_base_dimensions(area, ratio, 64)
+        finally:
+            blo.logger.removeHandler(handler)
+            blo.logger.setLevel(previous)
+
+        self.assertEqual([r.getMessage() for r in records], [])
 
 
 class TestComputeLatentFrames(unittest.TestCase):
@@ -284,6 +359,19 @@ class TestNodes(unittest.TestCase):
             latent, _, _, _, _, _ = node.generate("1:1", "1", 2.0, "FLUX", 1, length=48)
         self.assertEqual(len(latent["samples"].shape), 4)
         self.assertTrue(any("length=48 ignored" in line for line in captured.output))
+
+    def test_dtype_is_passed_for_image_families_only(self):
+        # Matches ComfyUI: EmptyLatentImage / EmptySD3LatentImage pass
+        # dtype=intermediate_dtype(); the video latent nodes pass only device.
+        # Outside ComfyUI there is no intermediate_dtype(), so nothing is passed.
+        node = blo.BobsLatentNode()
+        expect_dtype = blo._latent_dtype() is not None
+        for model, spec in blo.MODEL_SPECS.items():
+            latent, _, _, _, _, _ = node.generate("1:1", "1", 2.0, model, 1)
+            samples = latent["samples"]
+            self.assertEqual(
+                samples.dtype_was_passed, expect_dtype and spec["dims"] == 2, model
+            )
 
     def test_pixel_space_models_have_no_downscale(self):
         # vae_scale of 1 means the latent dims equal the pixel dims.


### PR DESCRIPTION
## Summary

Fixes from a review of the 1.3.0–1.5.0 work. **No shape changes** — `FLUX 16:9 @1MP` is still `1344x768`, and every model's channel count, VAE downscale and rank are untouched. Verified by sweeping all 30 families × 10 presets × 4 aspect ratios and comparing latent shapes against the reported pixel size.

## 1. Comma in aspect ratios produced a silent wrong answer

`","` was a separator, so a decimal-comma locale typing `1,5` (meaning 1.5) got:

```
"1,5"  -> 0.2000     # read as 1:5
"16,9" -> 1.7778
```

A 7.5× wrong aspect ratio, with no error. Before 1.3.0 this raised a clear `ValueError` (`int("1,5")` fails), so the rewrite **turned a loud error into a silent wrong result** — strictly worse than what it replaced. The comma is rejected again.

The upside was near zero: nobody writes `16,9` for an aspect ratio in English. `16:9`, `16/9`, `16x9` and `1.5:1` all still work.

**Breaking, deliberately:** if you were passing `16,9`, use `16:9`.

## 2. No upper bound on dimensions

ComfyUI caps width/height at `MAX_RESOLUTION = 16384` (`nodes.py:54`) and every built-in latent node enforces it. This node enforced only the lower bound:

| Input | Before | After |
| --- | --- | --- |
| `1000:1` @ 1MP | 32384 × 64 | 16384 × 64 |
| `1000:1` @ 16MP | 129536 × 128 | 16384 × 64 |
| `100:1` @ 16MP | 40960 × 384 | 16384 × 192 |

The latent tensor itself stays small, so this doesn't fail at allocation — it fails later in the sampler or VAE decode, a long way from the aspect ratio that caused it. Dimensions are now scaled down to fit the ceiling *before* aligning, so the aspect ratio survives whenever the floor doesn't also bind.

## 3. Clamping was silent

Both the floor and the new ceiling distort the requested ratio or area, so each now warns. The pre-1.3.0 code warned on the floor clamp and the rewrite dropped it — inconsistent with the standard set elsewhere in the same file, where `length`-on-image-models warns for exactly this reason.

Verified that ordinary sizes (5 common ratios × 3 areas) emit no warnings, so this isn't noisy.

## 4. `dtype` fidelity gap against `EmptyLatentImage`

`torch.zeros` was passed `device=` only. ComfyUI's `EmptyLatentImage` (`nodes.py:1248`) and `EmptySD3LatentImage` (`nodes_sd3.py:58`) both also pass `dtype=comfy.model_management.intermediate_dtype()`. The stated goal was to match `EmptyLatentImage`, and only half of it was carried over.

Image families now pass dtype; **video families still pass only `device`**, matching ComfyUI's video latent nodes (`nodes_wan.py:42`, `nodes_hunyuan.py:61`), which genuinely differ here. A test pins that split so it can't drift.

## Testing

52 tests, up from 45. The new ones cover the resolution ceiling across every family, both clamp warnings, the no-warning-on-normal-sizes case, comma rejection, and the dtype split — i.e. the coverage gap that let findings 2 and 3 through in the first place.

```
python -m unittest discover -s tests -v
```

One thing I checked and found **clean**: I suspected the `min(size, total)` clamp in `compute_tile_dimensions` could return a non-multiple-of-8 tile. Brute-forced every family × preset × 6 ratios × 6 upscale factors plus the public function at degenerate sizes — 0 violations, because `tiles` is always ≥ 2. No change needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbDZTWCvSqbXEX3GHJkSXw)_